### PR TITLE
Fix non-unique car title spawning.

### DIFF
--- a/lua/autorun/photon/sh_emv_vehicles.lua
+++ b/lua/autorun/photon/sh_emv_vehicles.lua
@@ -57,7 +57,7 @@ function EMVU:SpawnedVehicle( ent )
 	if not car then return end
 	if not raw or not istable( raw.EMV ) then raw = car end
 
-	if SERVER and istable( car.EMV ) then
+	if SERVER and istable( raw.EMV ) then
 		EMVU:MakeEMV( ent, raw.EMV )
 	end
 end


### PR DESCRIPTION
When multiple car classes share the same title, the for loop breaks during lookup.
This resolves that and allows them to spawn correctly.