### PR TITLE
Replace list.Get with list.GetForEdit

### DIFF
--- a/lua/autorun/photon/cl_emv_init.lua
+++ b/lua/autorun/photon/cl_emv_init.lua
@@ -62,7 +62,7 @@ local function DrawCarLights()
 	for _, ent in pairs(Photon:AllVehicles() ) do
 		if IsValid(ent) and ent:Photon() then
 			if not ent.Photon_RenderLights then
-				Photon:SetupCar(ent, list.Get("Vehicles")[ent:GetVehicleClass()].Name)
+				Photon:SetupCar(ent, list.GetForEdit("Vehicles")[ent:GetVehicleClass()].Name)
 			else
 				if should_render_reg:GetBool() then
 					ent:Photon_RenderLights(

--- a/lua/autorun/photon/sh_emv_vehicles.lua
+++ b/lua/autorun/photon/sh_emv_vehicles.lua
@@ -45,10 +45,11 @@ function EMVU:SpawnedVehicle( ent )
 	local vehicleTable = Photon:GetVehicleTable( ent )
 	local name = vehicleTable.Name
 	ent.Name = name
-	local raw = list.Get("Vehicles")[name]
+	local vehicles = list.GetForEdit("Vehicles")
+	local raw = vehicles[name]
 	local car = false
 
-	for _,scar in pairs(list.Get("Vehicles")) do
+	for _,scar in pairs(vehicles) do
 		if scar.Name == name then
 			car = scar
 			break

--- a/lua/autorun/photon/sh_photon_vehicles.lua
+++ b/lua/autorun/photon/sh_photon_vehicles.lua
@@ -14,13 +14,13 @@ function Photon:RecoverVehicleName( ent )
 
 	if ent.GetVehicleClass and ent:GetVehicleClass() then
 		local vehicleClass = ent:GetVehicleClass()
-		local vehicleTable = list.Get("Vehicles")[vehicleClass]
+		local vehicleTable = list.GetForEdit("Vehicles")[vehicleClass]
 		if vehicleTable and istable(vehicleTable) then
 			return vehicleClass
 		end
 	end
 
-	for key,car in pairs( list.Get("Vehicles") ) do
+	for key,car in pairs( list.GetForEdit("Vehicles") ) do
 		if string.lower(car.Model) == string.lower(model) then
 			return key
 		end
@@ -60,7 +60,7 @@ function Photon:EntityCreated( ent )
 						local class = ent:GetClass()
 					end
 
-					local lst = list.Get("Vehicles")[class]
+					local lst = list.GetForEdit("Vehicles")[class]
 					if lst and istable(lst) then
 						ent.VehicleName = class
 						Photon:SpawnedVehicle( ent )
@@ -257,7 +257,7 @@ function Photon:GetVehicleTable(ent)
 
 	local vehicleName = ent.VehicleName
 	if isstring(vehicleName) and vehicleName ~= "" then
-		local vehicleTable = list.Get("Vehicles")[vehicleName] -- list.GetEntry("Vehicles", vehicleName)
+		local vehicleTable = list.GetForEdit("Vehicles")[vehicleName] -- list.GetEntry("Vehicles", vehicleName)
 		if istable(vehicleTable) then
 			return vehicleTable
 		end


### PR DESCRIPTION
A lot of hot paths use list.Get which does a full copy of the vehicles table every time, which can absolutely murder performance.
This replaces a bunch of those with GetForEdit, which is a mutable copy but means we can actually load.