### PR TITLE
fix: stop multiplying siren SoundLevel (map-wide audio)

### DIFF
--- a/lua/autorun/photon/cl_emv_meta.lua
+++ b/lua/autorun/photon/cl_emv_meta.lua
@@ -1047,7 +1047,8 @@ net.Receive("Photon.ELS_PlaySiren", function()
 		local sound = net.ReadString()
 		local volume = net.ReadFloat()
 		ent.EMVU_Siren = CreateSound(ent, sound)
-		ent.EMVU_Siren:SetSoundLevel( volume * 1.8 )
+		-- Volume is a Source SNDLVL (default 75); do not scale it.
+		ent.EMVU_Siren:SetSoundLevel( volume )
 		if ent:GetThirdPersonMode() then
 			ent.EMVU_Siren:PlayEx(thirdPersonVolume, 100)
 		elseif !ent:GetThirdPersonMode() then
@@ -1082,7 +1083,7 @@ net.Receive("Photon.ELS_PlaySiren2", function()
 		local sound = net.ReadString()
 		local volume = net.ReadFloat()
 		ent.EMVU_Siren2 = CreateSound(ent, sound)
-		ent.EMVU_Siren2:SetSoundLevel( volume * 1.25 )
+		ent.EMVU_Siren2:SetSoundLevel( volume )
 		if ent:GetThirdPersonMode() then
 			ent.EMVU_Siren2:PlayEx(thirdPersonVolume, 100)
 		elseif !ent:GetThirdPersonMode() then
@@ -1117,7 +1118,7 @@ net.Receive("Photon.ELS_PlayManual", function()
 		local sound = net.ReadString()
 		local volume = net.ReadFloat()
 		ent.EMVU_ManualSiren = CreateSound(ent, sound)
-		ent.EMVU_ManualSiren:SetSoundLevel( volume * 1.25 )
+		ent.EMVU_ManualSiren:SetSoundLevel( volume )
 		if ent:GetThirdPersonMode() then
 			ent.EMVU_ManualSiren:PlayEx(thirdPersonVolume, 100)
 		elseif !ent:GetThirdPersonMode() then
@@ -1165,7 +1166,7 @@ net.Receive("Photon.ELS_PlayHorn", function()
 		local sound = net.ReadString()
 		local volume = net.ReadFloat()
 		ent.EMVU_Horn = CreateSound(ent, sound)
-		ent.EMVU_Horn:SetSoundLevel( volume * 1.25 )
+		ent.EMVU_Horn:SetSoundLevel( volume )
 		if ent:GetThirdPersonMode() then
 			ent.EMVU_Horn:PlayEx(thirdPersonVolume, 100)
 		elseif !ent:GetThirdPersonMode() then
@@ -1198,7 +1199,7 @@ hook.Add("NotifyShouldTransmit", "Photon.ShouldTransmitSirens", function(ent, sh
 		local sound = ent:GetNW2String("PhotonLE.Siren_Sound")
 		local volume = ent:GetNW2Float("PhotonLE.Siren_Volume")
 		ent.EMVU_Siren = CreateSound(ent, sound)
-		ent.EMVU_Siren:SetSoundLevel( volume * 0.05 )
+		ent.EMVU_Siren:SetSoundLevel( volume )
 		ent.EMVU_Siren:PlayEx(1, 100)
 		ent:CallOnRemove("StopSiren", function(ent)
 			if ent.EMVU_Siren then
@@ -1211,7 +1212,7 @@ hook.Add("NotifyShouldTransmit", "Photon.ShouldTransmitSirens", function(ent, sh
 		local sound = ent:GetNW2String("PhotonLE.Siren2_Sound")
 		local volume = ent:GetNW2Float("PhotonLE.Siren_Volume")
 		ent.EMVU_Siren2 = CreateSound(ent, sound)
-		ent.EMVU_Siren2:SetSoundLevel( volume * 0.05 )
+		ent.EMVU_Siren2:SetSoundLevel( volume )
 		ent.EMVU_Siren2:PlayEx(1, 100)
 		ent:CallOnRemove("StopSiren2", function(ent)
 			if ent.EMVU_Siren2 then
@@ -1224,7 +1225,7 @@ hook.Add("NotifyShouldTransmit", "Photon.ShouldTransmitSirens", function(ent, sh
 		local sound = ent:GetNW2String("PhotonLE.Manual_Sound")
 		local volume = ent:GetNW2Float("PhotonLE.Siren_Volume")
 		ent.EMVU_ManualSiren = CreateSound(ent, sound)
-		ent.EMVU_ManualSiren:SetSoundLevel( volume * 0.05 )
+		ent.EMVU_ManualSiren:SetSoundLevel( volume )
 		ent.EMVU_ManualSiren:PlayEx(1, 100)
 		ent:CallOnRemove("StopManualSiren", function(ent)
 			if ent.EMVU_ManualSiren then
@@ -1237,7 +1238,7 @@ hook.Add("NotifyShouldTransmit", "Photon.ShouldTransmitSirens", function(ent, sh
 		local sound = ent:GetNW2String("PhotonLE.Horn_Sound")
 		local volume = ent:GetNW2Float("PhotonLE.Siren_Volume")
 		ent.EMVU_Horn = CreateSound(ent, sound)
-		ent.EMVU_Horn:SetSoundLevel( volume * 0.05 )
+		ent.EMVU_Horn:SetSoundLevel( volume )
 		ent.EMVU_Horn:PlayEx(1, 100)
 		ent:CallOnRemove("StopHorn", function(ent)
 			if ent.EMVU_Horn then


### PR DESCRIPTION
## Summary
- Photon sends siren `Volume` as a Source **SNDLVL** (default **75**).
- Client `CreateSound` path was doing `SetSoundLevel(volume * 1.8)` (and `* 1.25` for secondary/horn/manual), so the effective level became **~135**.
- Source attenuation scales roughly with `10^((60-SNDLVL)/20)`, so 75→135 is about **1000×** farther — sirens audible across most of the map.
- PVS re-entry (`NotifyShouldTransmit`) used `volume * 0.05`, which went the other way (near-silent).

This restores pre-client-siren behavior: `SetSoundLevel(volume)` with no multiplier.

Introduced when sirens moved client-side in `b7da15a` / #200. Re-adding Photon on CityRP exposed it again after VCMOD ELS.

## Test plan
- [ ] Enable ELS siren on a police vehicle; walk away — should fall off at normal vehicle-siren distance, not map-wide
- [ ] Secondary siren / horn / manual still audible nearby at sensible range
- [ ] Leave and re-enter PVS with siren running — siren resumes at normal level (not whisper-quiet)
- [ ] Interior vs third-person volume ducking still works (unchanged `PlayEx` paths)


Made with [Cursor](https://cursor.com)