### PR TITLE
refactor: Network EMV string data via SimpleNet

### DIFF
--- a/lua/autorun/photon/cl_emv_init.lua
+++ b/lua/autorun/photon/cl_emv_init.lua
@@ -39,11 +39,9 @@ local function DrawEMVLights()
 	if not should_render:GetBool() then return end
 
 	for k, v in pairs(EMVU:AllVehicles()) do
-		if IsValid(v) and v.IsEMV and v:IsEMV() then
+		if IsValid(v) then
 			if v.Photon_RenderEL then
 				v:Photon_RenderEL()
-			else
-				EMVU:MakeEMV(v, v:EMVName())
 			end
 			if v.Photon_RenderIllum then
 				v:Photon_RenderIllum()

--- a/lua/autorun/photon/cl_emv_meta.lua
+++ b/lua/autorun/photon/cl_emv_meta.lua
@@ -31,9 +31,15 @@ end)
 
 local printedErrors = {}
 
+hook.Add("Photon.SimpleNet.ValueChanged", "Photon.SetupEMV", function(name, old, new, ent)
+	if name == "VehicleIndex" then
+		EMVU:MakeEMV(ent, new)
+	end
+end)
+
 function EMVU:MakeEMV( emv, name )
 
-	if not emv or not emv:IsValid() or not emv:IsVehicle() then return false end
+	if not emv or not emv:IsValid() or not emv:IsVehicle() or not emv:IsEMV() then return false end
 
 	if name == "1" then return end
 

--- a/lua/autorun/photon/emv/cl_meta.lua
+++ b/lua/autorun/photon/emv/cl_meta.lua
@@ -6,7 +6,7 @@
 @alias ENT
 --]]--
 
-local ENT = FindMetaTable("Vehicle")
+local ENT = FindMetaTable("Entity")
 
 --- Get lighting state.
 -- @rbool

--- a/lua/autorun/photon/emv/sh_meta.lua
+++ b/lua/autorun/photon/emv/sh_meta.lua
@@ -1,0 +1,39 @@
+--[[-- Emergency Lighting Vehicle Meta
+@copyright Photon Team
+@release development
+@author Photon Team
+@module VEHICLE
+@alias ENT
+--]]--
+
+local ENT = FindMetaTable("Vehicle")
+
+function ENT:EMVName()
+	return self:GetPhotonNet_VehicleIndex("")
+end
+
+function ENT:Photon_GetUnitNumber()
+	return self:GetPhotonNet_UnitNumber("")
+end
+
+function ENT:Photon_GetLiveryID()
+	return self:GetPhotonNet_LiveryID("")
+end
+
+function ENT:Photon_SelectionString()
+	return self:GetPhotonNet_SelectionString("")
+end
+
+function ENT:Photon_SelectionTable()
+	return string.Split(self:Photon_SelectionString(), ".")
+end
+
+function ENT:Photon_GetUtilStringTable()
+	return {
+		"",
+		self:EMVName(),
+		self:Photon_GetUnitNumber(),
+		self:Photon_GetLiveryID(),
+		self:Photon_SelectionString()
+	}
+end

--- a/lua/autorun/photon/emv/sh_meta.lua
+++ b/lua/autorun/photon/emv/sh_meta.lua
@@ -6,7 +6,7 @@
 @alias ENT
 --]]--
 
-local ENT = FindMetaTable("Vehicle")
+local ENT = FindMetaTable("Entity")
 
 function ENT:EMVName()
 	return self:GetPhotonNet_VehicleIndex("")

--- a/lua/autorun/photon/emv/sh_meta.lua
+++ b/lua/autorun/photon/emv/sh_meta.lua
@@ -21,7 +21,7 @@ function ENT:Photon_GetLiveryID()
 end
 
 function ENT:Photon_SelectionString()
-	return self:GetPhotonNet_SelectionString("")
+	return self:GetPhotonNet_SelectionString(".")
 end
 
 function ENT:Photon_SelectionTable()

--- a/lua/autorun/photon/emv/sv_meta.lua
+++ b/lua/autorun/photon/emv/sv_meta.lua
@@ -250,3 +250,44 @@ end
 function ENT:ELS_HasAuxSiren()
 	return self:ELS_AuxSirenSet() ~= nil and self:ELS_AuxSirenSet() ~= 0
 end
+
+function ENT:Photon_SetLiveryId(val)
+	return self:SetPhotonNet_UnitNumber(val)
+end
+
+function ENT:Photon_SetUnitNumber(val)
+	val = tostring(val):upper()
+	if #val > 3 then
+		val = string.sub(val, 1, 3)
+	end
+	if not val:match("%w") then
+		val = ""
+	end
+	if PHOTON_BANNED_UNIT_IDS[val:lower()] then
+		val = ""
+	end
+
+	return self:GetPhotonNet_LiveryID(val)
+end
+
+function ENT:Photon_SetSelection(index, value)
+	if not istable(EMVU.Selections[self.Name][index]) then
+		return
+	end
+
+	local selectionTable = self:Photon_SelectionTable()
+	selectionTable[index] = value
+	PrintTable(selectionTable)
+	print()
+	print(index, value, table.concat(selectionTable, "."))
+	print("--")
+	self:SetPhotonNet_SelectionString(table.concat(selectionTable, "."))
+
+	local selectionData = EMVU.Selections[self.Name][index].Options[value]
+
+	if istable(selectionData.Bodygroups) then
+		for _, bgData in ipairs(selectionData.Bodygroups) do
+			self:SetBodygroup(bgData[1], bgData[2])
+		end
+	end
+end

--- a/lua/autorun/photon/emv/sv_meta.lua
+++ b/lua/autorun/photon/emv/sv_meta.lua
@@ -277,10 +277,6 @@ function ENT:Photon_SetSelection(index, value)
 
 	local selectionTable = self:Photon_SelectionTable()
 	selectionTable[index] = value
-	PrintTable(selectionTable)
-	print()
-	print(index, value, table.concat(selectionTable, "."))
-	print("--")
 	self:SetPhotonNet_SelectionString(table.concat(selectionTable, "."))
 
 	local selectionData = EMVU.Selections[self.Name][index].Options[value]

--- a/lua/autorun/photon/emv/sv_meta.lua
+++ b/lua/autorun/photon/emv/sv_meta.lua
@@ -29,7 +29,8 @@ end
 -- @bool[opt] val New siren state.
 -- @rbool The new set value.
 function ENT:SetPhotonLEStayOn(val)
-	return self:SetPhotonNet_LEStayOn(val)
+	self:SetPhotonNet_LEStayOn(val)
+	return self:GetPhotonNet_LEStayOn(false)
 end
 
 --- Sets if the vehicle has ELS enabled.
@@ -252,7 +253,8 @@ function ENT:ELS_HasAuxSiren()
 end
 
 function ENT:Photon_SetLiveryId(val)
-	return self:SetPhotonNet_LiveryID(val)
+	self:SetPhotonNet_LiveryID(val)
+	return self:Photon_GetLiveryID()
 end
 
 function ENT:Photon_SetUnitNumber(val)
@@ -267,7 +269,8 @@ function ENT:Photon_SetUnitNumber(val)
 		val = ""
 	end
 
-	return self:SetPhotonNet_UnitNumber(val)
+	self:SetPhotonNet_UnitNumber(val)
+	return self:Photon_GetUnitNumber()
 end
 
 function ENT:Photon_SetSelection(index, value)

--- a/lua/autorun/photon/emv/sv_meta.lua
+++ b/lua/autorun/photon/emv/sv_meta.lua
@@ -6,7 +6,7 @@
 @alias ENT
 --]]--
 
-local ENT = FindMetaTable("Vehicle")
+local ENT = FindMetaTable("Entity")
 local helper = EMVU.Helper
 
 local global_stayon = GetConVar("photon_emv_stayon")

--- a/lua/autorun/photon/emv/sv_meta.lua
+++ b/lua/autorun/photon/emv/sv_meta.lua
@@ -252,7 +252,7 @@ function ENT:ELS_HasAuxSiren()
 end
 
 function ENT:Photon_SetLiveryId(val)
-	return self:SetPhotonNet_UnitNumber(val)
+	return self:SetPhotonNet_LiveryID(val)
 end
 
 function ENT:Photon_SetUnitNumber(val)
@@ -267,7 +267,7 @@ function ENT:Photon_SetUnitNumber(val)
 		val = ""
 	end
 
-	return self:GetPhotonNet_LiveryID(val)
+	return self:SetPhotonNet_UnitNumber(val)
 end
 
 function ENT:Photon_SetSelection(index, value)

--- a/lua/autorun/photon/sh_emv_init.lua
+++ b/lua/autorun/photon/sh_emv_init.lua
@@ -65,6 +65,7 @@ include( "library/emv_auto.lua" )
 
 Photon.include("emv/cl_meta.lua")
 Photon.include("emv/sv_meta.lua")
+Photon.include("emv/sh_meta.lua")
 
 local emvVehicleTable = {}
 local emvLastScan = 0

--- a/lua/autorun/photon/sh_emv_meta.lua
+++ b/lua/autorun/photon/sh_emv_meta.lua
@@ -9,8 +9,7 @@ local istable = istable
 function ent:IsEMV()
 	if not IsValid( self ) then return false end
 	if not EMV_INDEX then return false end
-	local str = self:GetNW2String( "PhotonLE.EMV_INDEX" )
-	if string.StartWith( tostring(str), "ö" ) then return true end
+	if self:EMVName() ~= "" then return true end
 	return false
 end
 
@@ -26,15 +25,6 @@ function ent:HasPhotonELS()
 	return true
 end
 
-function ent:EMVName()
-	if not IsValid( self ) then return "" end
-	if not EMV_INDEX then return "" end
-	if self:IsEMV() then
-		return string.Explode( "ö", self:GetNW2String( "PhotonLE.EMV_INDEX" ), false )[2]
-	end
-	return ""
-end
-
 function ent:Photon_GetSpeed()
 	if not IsValid( self ) then return 0 end
 	return self:GetVelocity():Length()
@@ -43,14 +33,6 @@ end
 function ent:Photon_AdjustedSpeed()
 	if not IsValid( self ) then return 0 end
 	return ( self:GetVelocity():Length() * ( 3600 / 63360 ) )
-end
-
-function ent:Photon_GetUnitNumber()
-	return string.Explode( "ö", self:GetNW2String( "PhotonLE.EMV_INDEX" ), false )[3] or ""
-end
-
-function ent:Photon_GetLiveryID()
-	return string.Explode( "ö", self:GetNW2String( "PhotonLE.EMV_INDEX" ), false )[4] or ""
 end
 
 function ent:Photon_GetAutoSkinIndex()
@@ -75,16 +57,9 @@ end
 ent.LegacySetSkin = ent.LegacySetSkin or ent.SetSkin
 function ent:SetSkin( index )
 	self:LegacySetSkin( index )
-	hook.Call( "Photon.EntityChangedSkin", GM, self, index )
-end
-
-function ent:Photon_SelectionString()
-	return string.Explode( "ö", self:GetNW2String( "PhotonLE.EMV_INDEX" ), false )[5]
-end
-
-function ent:Photon_SelectionTable()
-	local selectionString =  string.Explode( "ö", self:GetNW2String( "PhotonLE.EMV_INDEX" ), false )[5]
-	return string.Explode( ".", selectionString, false )
+	if self:IsVehicle() and self:IsEMV() then
+		hook.Call( "Photon.EntityChangedSkin", GM, self, index )
+	end
 end
 
 function ent:Photon_SelectionOption( index )
@@ -182,10 +157,6 @@ function ent:Photon_ImportSelectionData( inputData )
 		self:Photon_ApplyEquipmentPreset( resultTable )
 	end
 	return resultTable
-end
-
-function ent:Photon_GetUtilStringTable()
-	return string.Explode( "ö", self:GetNW2String( "PhotonLE.EMV_INDEX" ), false )
 end
 
 function ent:Photon_SelectionEnabled()

--- a/lua/autorun/photon/sh_emv_meta.lua
+++ b/lua/autorun/photon/sh_emv_meta.lua
@@ -8,6 +8,7 @@ local istable = istable
 
 function ent:IsEMV()
 	if not IsValid( self ) then return false end
+	if not self:IsVehicle() then return false end
 	if not EMV_INDEX then return false end
 	if self:EMVName() ~= "" then return true end
 	return false

--- a/lua/autorun/photon/shared/sh_simplenet.lua
+++ b/lua/autorun/photon/shared/sh_simplenet.lua
@@ -149,7 +149,10 @@ if CLIENT then
 		local ent = net.ReadEntity()
 		local idx = net.ReadUInt(NET.Bits)
 		local name, netType, extra = unpack(NET.FMap[idx])
-		ent[NET.Normalise(name)] = NET.ReadFunctions[netType](extra)
+		local normalName = NET.Normalise(name)
+		local old = ent[normalName]
+		ent[normalName] = NET.ReadFunctions[netType](extra)
+		hook.Run("Photon.SimpleNet.ValueChanged", name, old, ent[normalName])
 	end)
 
 	hook.Add("NotifyShouldTransmit", "EMVU.Net.NotifyShouldTransmit", function(ent, shouldTransmit)

--- a/lua/autorun/photon/shared/sh_simplenet.lua
+++ b/lua/autorun/photon/shared/sh_simplenet.lua
@@ -164,7 +164,7 @@ if CLIENT then
 	end)
 end
 
-local UInt, Bool = NET.UINT, NET.BOOL
+local UInt, Bool, Str = NET.UINT, NET.BOOL, NET.STR
 
 NET:Map("CurrentSignal", UInt, 2)
 NET:Map("Blinker", UInt, 2)
@@ -187,3 +187,8 @@ NET:Map("TrafficOption", UInt, 4)
 NET:Map("IlluminationOn", Bool)
 NET:Map("IlluminationOption", UInt, 4)
 NET:Map("Preset", UInt, 10)
+
+NET:Map("VehicleIndex", Str)
+NET:Map("UnitNumber", Str)
+NET:Map("LiveryID", Str)
+NET:Map("SelectionString", Str)

--- a/lua/autorun/photon/shared/sh_simplenet.lua
+++ b/lua/autorun/photon/shared/sh_simplenet.lua
@@ -125,30 +125,99 @@ if SERVER then
 		end
 	end
 
-	--- Resend every currently-set networked variable on every vehicle to a
-	-- player, batched into a single net message.
-	-- Needed because values are only broadcast when they change, so a player
-	-- who joins after a value was set would otherwise never receive it.
-	-- @ply to Player to send the current state to.
+	local resyncRate = CreateConVar(
+		"photon_simplenet_resync_rate", "32", FCVAR_ARCHIVE,
+		"Maximum number of vehicles the SimpleNet resync queue sends to each player per frame"
+	)
+
+	-- [player] = {list = {ent, ...}, set = {[ent] = true}, pos = <next index to send>}
+	NET.ResyncQueue = NET.ResyncQueue or {}
+
+	-- Entries are deduped, so a legitimate queue never exceeds the number of
+	-- vehicles on the map. The cap only bounds memory if a client spams
+	-- requests faster than the queue drains.
+	local MAX_QUEUED = 8192
+
+	--- Collect every currently-set networked variable on an entity.
+	-- @ent ent Entity to read the values from.
+	-- @treturn table|nil Array of {idx, netType, extra, val}, or nil if nothing is set.
 	-- @internal
 	-- @state server
-	function NET:Resync(to)
-		local groups = {}
-		for _, ent in ipairs(ents.GetAll()) do
-			if IsValid(ent) and ent:IsVehicle() then
-				local fields
-				for name in pairs(self.RMap) do
-					local val = ent[self.Normalise(name)]
-					if val ~= nil then
-						fields = fields or {}
-						local idx, netType, extra = unpack(self.RMap[name])
-						fields[#fields + 1] = {idx, netType, extra, val}
-					end
-				end
+	function NET:CollectFields(ent)
+		local fields
+		for name, mapping in pairs(self.RMap) do
+			local val = ent[self.Normalise(name)]
+			if val ~= nil then
+				fields = fields or {}
+				local idx, netType, extra = unpack(mapping)
+				fields[#fields + 1] = {idx, netType, extra, val}
+			end
+		end
+
+		return fields
+	end
+
+	--- Queue vehicles to have their full networked state sent to a player.
+	-- Values are only broadcast when they change, so a client that has just
+	-- become aware of an entity has to pull the current state explicitly.
+	-- @ply ply Player to send the current state to.
+	-- @tab targets Array of entities to queue.
+	-- @internal
+	-- @state server
+	function NET:QueueResync(ply, targets)
+		local queue = self.ResyncQueue[ply]
+		if not queue then
+			queue = {list = {}, set = {}, pos = 1}
+			self.ResyncQueue[ply] = queue
+		end
+
+		for _, ent in ipairs(targets) do
+			if #queue.list - queue.pos >= MAX_QUEUED then break end
+
+			if IsValid(ent) and not queue.set[ent] then
+				queue.set[ent] = true
+				queue.list[#queue.list + 1] = ent
+			end
+		end
+	end
+
+	--- Drain up to `count` vehicles from a player's queue into one net message.
+	-- Draining over several frames keeps any single message well under the
+	-- 64KiB net limit, which a whole-map resync could otherwise exceed.
+	-- @ply ply Player to send to.
+	-- @int count Maximum number of vehicles to process this frame.
+	-- @internal
+	-- @state server
+	function NET:SendQueuedResync(ply, count)
+		local queue = self.ResyncQueue[ply]
+		if not queue then return end
+
+		local groups, processed = {}, 0
+		while processed < count and queue.pos <= #queue.list do
+			local ent = queue.list[queue.pos]
+			queue.pos = queue.pos + 1
+			processed = processed + 1
+			queue.set[ent] = nil
+
+			if IsValid(ent) then
+				local fields = self:CollectFields(ent)
 				if fields then
 					groups[#groups + 1] = {ent, fields}
 				end
 			end
+		end
+
+		if queue.pos > #queue.list then
+			self.ResyncQueue[ply] = nil
+		elseif queue.pos > MAX_QUEUED then
+			-- Reclaim the drained prefix so a queue that never fully empties
+			-- does not grow its backing array without bound.
+			local remaining, n = {}, 0
+			for i = queue.pos, #queue.list do
+				n = n + 1
+				remaining[n] = queue.list[i]
+			end
+			queue.list, queue.pos = remaining, 1
 		end
 
 		if #groups == 0 then return end
@@ -165,14 +234,20 @@ if SERVER then
 				self.WriteFunctions[netType](val, extra)
 			end
 		end
-		net.Send(to)
+		net.Send(ply)
 	end
 
-	hook.Add("PlayerInitialSpawn", "Photon.SimpleNet.Resync", function(ply)
-		timer.Simple(2, function()
-			if not IsValid(ply) then return end
-			NET:Resync(ply)
-		end)
+	hook.Add("Think", "Photon.SimpleNet.ResyncQueue", function()
+		if not next(NET.ResyncQueue) then return end
+
+		local count = math.max(1, resyncRate:GetInt())
+		for ply in pairs(NET.ResyncQueue) do
+			if IsValid(ply) then
+				NET:SendQueuedResync(ply, count)
+			else
+				NET.ResyncQueue[ply] = nil
+			end
+		end
 	end)
 end
 
@@ -190,33 +265,53 @@ end
 
 if SERVER then
 	net.Receive("Photon_SimpleNet_RequestSync", function(len, ply)
-		local ent = net.ReadEntity()
-		if IsValid(ent) and ent.IsEMV and ent:IsEMV() then
-			for k,v in pairs(NET.RMap) do
-				local varName = NET.Normalise(k)
-				local varValue = ent[varName]
-				if varValue then
-					local idx, netType, extra = unpack(v)
-					net.Start("Photon_SimpleNet_Change")
-					net.WriteEntity(ent)
-					net.WriteUInt(idx, NET.Bits)
-					NET.WriteFunctions[netType](varValue, extra)
-					net.Send(ply)
-				end
+		local count = net.ReadUInt(14) -- 8192 edicts is the engine ceiling
+
+		local targets = {}
+		for _ = 1, count do
+			local ent = net.ReadEntity()
+			-- Deliberately not gated on IsEMV: the map also covers regular car
+			-- variables (signals, headlights, brakes, engine), so an EMV-only
+			-- gate would drop resyncs for every non-emergency Photon vehicle.
+			if IsValid(ent) and ent:IsVehicle() then
+				targets[#targets + 1] = ent
 			end
+		end
+
+		if #targets > 0 then
+			NET:QueueResync(ply, targets)
 		end
 	end)
 end
 
 if CLIENT then
+	--- Apply a received value to an entity and notify listeners.
+	-- @ent ent Entity to apply to.
+	-- @str name Registered variable name.
+	-- @param val Value that was read off the wire.
+	-- @internal
+	-- @state client
+	local function ApplyValue(ent, name, val)
+		local normalName = NET.Normalise(name)
+		local old = ent[normalName]
+		ent[normalName] = val
+		hook.Run("Photon.SimpleNet.ValueChanged", name, old, val, ent)
+	end
+
 	net.Receive("Photon_SimpleNet_Change", function()
 		local ent = net.ReadEntity()
 		local idx = net.ReadUInt(NET.Bits)
-		local name, netType, extra = unpack(NET.FMap[idx])
-		local normalName = NET.Normalise(name)
-		local old = ent[normalName]
-		ent[normalName] = NET.ReadFunctions[netType](extra)
-		hook.Run("Photon.SimpleNet.ValueChanged", name, old, ent[normalName], ent)
+		local mapping = NET.FMap[idx]
+		if not mapping then return end
+
+		local name, netType, extra = unpack(mapping)
+		local val = NET.ReadFunctions[netType](extra)
+
+		-- Changes are broadcast to everyone, so the entity may not exist for
+		-- this client yet. NetworkEntityCreated pulls the state when it does.
+		if not IsValid(ent) then return end
+
+		ApplyValue(ent, name, val)
 	end)
 
 	net.Receive("Photon_SimpleNet_Resync", function()
@@ -226,24 +321,69 @@ if CLIENT then
 			local fieldCount = net.ReadUInt(NET.Bits)
 			for _ = 1, fieldCount do
 				local idx = net.ReadUInt(NET.Bits)
-				local name, netType, extra = unpack(NET.FMap[idx])
+				local mapping = NET.FMap[idx]
+				-- An unknown index means the rest of the message cannot be
+				-- realigned, so abandon it rather than reading garbage.
+				if not mapping then return end
+
+				local name, netType, extra = unpack(mapping)
 				local val = NET.ReadFunctions[netType](extra)
 				if IsValid(ent) then
-					local normalName = NET.Normalise(name)
-					local old = ent[normalName]
-					ent[normalName] = val
-					hook.Run("Photon.SimpleNet.ValueChanged", name, old, val, ent)
+					ApplyValue(ent, name, val)
 				end
 			end
 		end
 	end)
 
-	hook.Add("NotifyShouldTransmit", "EMVU.Net.NotifyShouldTransmit", function(ent, shouldTransmit)
-		if shouldTransmit and ent.IsEMV and ent:IsEMV() then
-			net.Start("Photon_SimpleNet_RequestSync")
-			net.WriteEntity(ent)
-			net.SendToServer()
+	local pending, flushQueued = {}, false
+
+	--- Send one batched sync request for every vehicle queued this frame.
+	-- @internal
+	-- @state client
+	local function FlushSyncRequests()
+		flushQueued = false
+
+		local targets, count = {}, 0
+		for ent in pairs(pending) do
+			if IsValid(ent) then
+				count = count + 1
+				targets[count] = ent
+			end
 		end
+		table.Empty(pending)
+		if count == 0 then return end
+
+		net.Start("Photon_SimpleNet_RequestSync")
+		net.WriteUInt(count, 14) -- 8192 edicts is the engine ceiling
+		for i = 1, count do
+			net.WriteEntity(targets[i])
+		end
+		net.SendToServer()
+	end
+
+	--- Queue a vehicle for a full state sync from the server.
+	-- Requests are debounced into a single message because joining a server
+	-- fires NetworkEntityCreated for every entity in the initial PVS at once.
+	-- @ent ent Entity to request state for.
+	-- @internal
+	-- @state client
+	local function RequestSync(ent)
+		-- Gated on IsVehicle rather than IsEMV: IsEMV reads VehicleIndex, which
+		-- is exactly the value an unsynced client is missing, so an EMV gate
+		-- here can never recover a vehicle it has no state for.
+		if not IsValid(ent) or not ent:IsVehicle() then return end
+
+		pending[ent] = true
+		if not flushQueued then
+			flushQueued = true
+			timer.Simple(0, FlushSyncRequests)
+		end
+	end
+
+	hook.Add("NetworkEntityCreated", "Photon.SimpleNet.RequestSync", RequestSync)
+
+	hook.Add("NotifyShouldTransmit", "EMVU.Net.NotifyShouldTransmit", function(ent, shouldTransmit)
+		if shouldTransmit then RequestSync(ent) end
 	end)
 end
 

--- a/lua/autorun/photon/shared/sh_simplenet.lua
+++ b/lua/autorun/photon/shared/sh_simplenet.lua
@@ -152,7 +152,7 @@ if CLIENT then
 		local normalName = NET.Normalise(name)
 		local old = ent[normalName]
 		ent[normalName] = NET.ReadFunctions[netType](extra)
-		hook.Run("Photon.SimpleNet.ValueChanged", name, old, ent[normalName])
+		hook.Run("Photon.SimpleNet.ValueChanged", name, old, ent[normalName], ent)
 	end)
 
 	hook.Add("NotifyShouldTransmit", "EMVU.Net.NotifyShouldTransmit", function(ent, shouldTransmit)

--- a/lua/autorun/photon/shared/sh_simplenet.lua
+++ b/lua/autorun/photon/shared/sh_simplenet.lua
@@ -91,11 +91,13 @@ if SERVER then
 	-- @internal
 	-- @state server
 	function NET:SendChange(ent, name, val, to)
-		local idx, netType, extra = unpack(self.RMap[name])
-		if not idx then
-			PhotonError(("Attempted to call SimpleNet:Change with an unregistered name: %s"):format(name))
+		local mapping = self.RMap[name]
+		if not mapping then
+			PhotonError(("Attempted to call SimpleNet:SendChange with an unregistered name: %s"):format(name))
 			return
 		end
+
+		local idx, netType, extra = unpack(mapping)
 
 		net.Start("Photon_SimpleNet_Change")
 		net.WriteEntity(ent)

--- a/lua/autorun/photon/shared/sh_simplenet.lua
+++ b/lua/autorun/photon/shared/sh_simplenet.lua
@@ -5,7 +5,6 @@ Easily optimise networking for setting local values on entities.
 @author Photon Team
 @module Photon.SNet
 @alias NET
-@todo Add Spawn-Sync for all Photon Variables.
 --]]--
 
 Photon = Photon or {}
@@ -16,6 +15,7 @@ local ENT = FindMetaTable("Entity")
 if SERVER then
 	util.AddNetworkString("Photon_SimpleNet_Change")
 	util.AddNetworkString("Photon_SimpleNet_RequestSync")
+	util.AddNetworkString("Photon_SimpleNet_Resync")
 end
 
 NET.BOOL = 1
@@ -83,6 +83,31 @@ function NET:Map(name, netType, extra)
 end
 
 if SERVER then
+	--- Send the current value of a networked variable to a recipient.
+	-- @ent ent The entity the value belongs to.
+	-- @str name The name to send.
+	-- @param val Value to send.
+	-- @param[opt] to Player to send to. Broadcasts to everyone if omitted.
+	-- @internal
+	-- @state server
+	function NET:SendChange(ent, name, val, to)
+		local idx, netType, extra = unpack(self.RMap[name])
+		if not idx then
+			PhotonError(("Attempted to call SimpleNet:Change with an unregistered name: %s"):format(name))
+			return
+		end
+
+		net.Start("Photon_SimpleNet_Change")
+		net.WriteEntity(ent)
+		net.WriteUInt(idx, self.Bits)
+		self.WriteFunctions[netType](val, extra)
+		if to then
+			net.Send(to)
+		else
+			net.Broadcast()
+		end
+	end
+
 	--- Change a networked entity variable.
 	-- @ent ent The entity to change the value on.
 	-- @str name The name to change.
@@ -96,20 +121,59 @@ if SERVER then
 		local old = ent[varName]
 		if val ~= old then
 			ent[varName] = val
-
-			local idx, netType, extra = unpack(self.RMap[name])
-			if not idx then
-				PhotonError(("Attempted to call SimpleNet:Change with an unregistered name: %s"):format(name))
-				return
-			end
-
-			net.Start("Photon_SimpleNet_Change")
-			net.WriteEntity(ent)
-			net.WriteUInt(idx, self.Bits)
-			self.WriteFunctions[netType](val, extra)
-			net.Broadcast()
+			self:SendChange(ent, name, val)
 		end
 	end
+
+	--- Resend every currently-set networked variable on every vehicle to a
+	-- player, batched into a single net message.
+	-- Needed because values are only broadcast when they change, so a player
+	-- who joins after a value was set would otherwise never receive it.
+	-- @ply to Player to send the current state to.
+	-- @internal
+	-- @state server
+	function NET:Resync(to)
+		local groups = {}
+		for _, ent in ipairs(ents.GetAll()) do
+			if IsValid(ent) and ent:IsVehicle() then
+				local fields
+				for name in pairs(self.RMap) do
+					local val = ent[self.Normalise(name)]
+					if val ~= nil then
+						fields = fields or {}
+						local idx, netType, extra = unpack(self.RMap[name])
+						fields[#fields + 1] = {idx, netType, extra, val}
+					end
+				end
+				if fields then
+					groups[#groups + 1] = {ent, fields}
+				end
+			end
+		end
+
+		if #groups == 0 then return end
+
+		net.Start("Photon_SimpleNet_Resync")
+		net.WriteUInt(#groups, 16)
+		for _, group in ipairs(groups) do
+			local ent, fields = group[1], group[2]
+			net.WriteEntity(ent)
+			net.WriteUInt(#fields, self.Bits)
+			for _, field in ipairs(fields) do
+				local idx, netType, extra, val = field[1], field[2], field[3], field[4]
+				net.WriteUInt(idx, self.Bits)
+				self.WriteFunctions[netType](val, extra)
+			end
+		end
+		net.Send(to)
+	end
+
+	hook.Add("PlayerInitialSpawn", "Photon.SimpleNet.Resync", function(ply)
+		timer.Simple(2, function()
+			if not IsValid(ply) then return end
+			NET:Resync(ply)
+		end)
+	end)
 end
 
 --- Get the latest cached version of a value on an entity.
@@ -153,6 +217,25 @@ if CLIENT then
 		local old = ent[normalName]
 		ent[normalName] = NET.ReadFunctions[netType](extra)
 		hook.Run("Photon.SimpleNet.ValueChanged", name, old, ent[normalName], ent)
+	end)
+
+	net.Receive("Photon_SimpleNet_Resync", function()
+		local entCount = net.ReadUInt(16)
+		for _ = 1, entCount do
+			local ent = net.ReadEntity()
+			local fieldCount = net.ReadUInt(NET.Bits)
+			for _ = 1, fieldCount do
+				local idx = net.ReadUInt(NET.Bits)
+				local name, netType, extra = unpack(NET.FMap[idx])
+				local val = NET.ReadFunctions[netType](extra)
+				if IsValid(ent) then
+					local normalName = NET.Normalise(name)
+					local old = ent[normalName]
+					ent[normalName] = val
+					hook.Run("Photon.SimpleNet.ValueChanged", name, old, val, ent)
+				end
+			end
+		end
 	end)
 
 	hook.Add("NotifyShouldTransmit", "EMVU.Net.NotifyShouldTransmit", function(ent, shouldTransmit)

--- a/lua/autorun/photon/shared/sh_simplenet.lua
+++ b/lua/autorun/photon/shared/sh_simplenet.lua
@@ -145,7 +145,7 @@ if SERVER then
 end
 
 if CLIENT then
-	net.Receive("Photon_SimpleNet_Change", function(len, ply)
+	net.Receive("Photon_SimpleNet_Change", function()
 		local ent = net.ReadEntity()
 		local idx = net.ReadUInt(NET.Bits)
 		local name, netType, extra = unpack(NET.FMap[idx])

--- a/lua/autorun/photon/sv_emv_meta.lua
+++ b/lua/autorun/photon/sv_emv_meta.lua
@@ -555,23 +555,6 @@ function EMVU:MakeEMV( ent, emv )
 		end
 	end
 
-	function ent:Photon_SetLiveryId( val )
-		local curdata = string.Explode( "ö", self:GetNW2String( "PhotonLE.EMV_INDEX" ), false )
-		curdata[4] = val
-		self:SetNW2String( "PhotonLE.EMV_INDEX", table.concat( curdata, "ö" ))
-	end
-
-	function ent:Photon_SetUnitNumber( val )
-		val = string.upper( tostring( val ) )
-		if string.len( val ) > 3 then val = string.sub( val, 1, 3 ) end
-		if not string.match( val, "%w" ) then val = "" end
-		if PHOTON_BANNED_UNIT_IDS[ string.lower( val ) ] then val = "" end
-		local curdata = string.Explode( "ö", self:GetNW2String( "PhotonLE.EMV_INDEX" ), false )
-		curdata[3] = val
-		self:SetNW2String( "PhotonLE.EMV_INDEX", table.concat( curdata, "ö" ) )
-		return val
-	end
-
 	function ent:Photon_ApplySubMaterials()
 		if istable( EMVU.SubMaterials[ self.Name ] ) then
 			local submaterials = EMVU.SubMaterials[ self.Name ]
@@ -583,35 +566,12 @@ function EMVU:MakeEMV( ent, emv )
 		end
 	end
 
-	function ent:Photon_SetSelection( index, value )
-			-- print(string.format( "index: %s value: %s", index, value ))
-		if istable( EMVU.Selections[ self.Name ][ index ] ) then
-			local selectionTable = self:Photon_SelectionTable()
-			selectionTable[index] = value
-			-- PrintTable( selectionTable )
-			local photonUtilString = self:Photon_GetUtilStringTable()
-			photonUtilString[5] = table.concat( selectionTable, "." )
-			--PrintTable( photonUtilString )
-			self:Photon_SetUtilString( table.concat( photonUtilString, "ö" ) )
-			local selectionData = EMVU.Selections[ self.Name ][ index ].Options[value]
-			if istable( selectionData.Bodygroups ) then
-				for _,bgData in pairs( selectionData.Bodygroups ) do
-					self:SetBodygroup( bgData[1], bgData[2] )
-				end
-			end
-		end
-	end
-
 	function ent:Photon_ResetSelections()
 		if istable( EMVU.Selections[ self.Name ] ) then
 			for i=1,#EMVU.Selections[ self.Name ] do
 				self:Photon_SetSelection( i, 1 )
 			end
 		end
-	end
-
-	function ent:Photon_SetUtilString( str )
-		self:SetNW2String( "PhotonLE.EMV_INDEX", str )
 	end
 
 	function ent:Photon_HasManualWind()
@@ -638,7 +598,7 @@ function EMVU:MakeEMV( ent, emv )
 	end
 
 	ent.IsEMV = true
-	ent:SetNW2String( "PhotonLE.EMV_INDEX", "ö" .. tostring( ent.Name ) .. "ööö." ) -- Al
+	ent:SetPhotonNet_VehicleIndex(ent.Name)
 
 	------ APPLY EMV PARAMETERS ------
 


### PR DESCRIPTION
## Summary

Replaces the ö-delimited `PhotonLE.EMV_INDEX` NW2String with four SimpleNet-networked string variables (`VehicleIndex`, `UnitNumber`, `LiveryID`, `SelectionString`), and adds the supporting SimpleNet infrastructure:

- **`Photon.SimpleNet.ValueChanged` hook** — fired clientside whenever a networked value changes, so systems can react to state arriving from the server.
- **String table meta** — new shared `emv/sh_meta.lua` with getters (`EMVName`, `Photon_GetUnitNumber`, `Photon_GetLiveryID`, `Photon_SelectionString`/`Table`), serverside setters in `emv/sv_meta.lua`, and removal of the old NW2String-based functions from `sh_emv_meta.lua` / `sv_emv_meta.lua`. Meta functions moved from the Vehicle to the Entity metatable.
- **Client EMV setup on receipt** — the client now runs `EMVU:MakeEMV` when `VehicleIndex` arrives via the hook, instead of polling in the render loop.
- **Resync queue** — values are only broadcast on change, so clients that join late (or get entities entering PVS) batch-request full state via `NetworkEntityCreated`/`NotifyShouldTransmit`; the server drains a per-player queue (rate-limited by `photon_simplenet_resync_rate`) to stay under the net message size limit.

## Notes

- Cherry-picked from `claude/commit-breakdown-prs-c17a8c` (17 commits, original history preserved). A self-cancelling debug add/remove pair (`7f65428`/`fcef7ed`) was dropped.
- Independent SimpleNet fixes (`IndexBits` off-by-one, `Get*` wrapper extra-arg) are split into their own PRs; they touch disjoint hunks of `sh_simplenet.lua` and merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)