### PR TITLE
chore: Ignore local tooling files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.luarc.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.luarc.json
+/.idea/


### PR DESCRIPTION
## Summary

Adds `/.luarc.json` and `/.idea/` to `.gitignore` so local Lua LSP config and JetBrains project files stay out of the repo.

Cherry-picked from `claude/commit-breakdown-prs-c17a8c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)