### PR TITLE
fix: Guard against missing or invalid preset data

### DIFF
--- a/lua/autorun/photon/sh_emv_helper.lua
+++ b/lua/autorun/photon/sh_emv_helper.lua
@@ -620,7 +620,7 @@ end
 function EMVU.Helper:GetPresetData( name, index )
 	local presets = EMVU.PresetIndex[ name ]
 	if not presets then return {} end
-	return presets[ index ]
+	return presets[ index ] or {}
 end
 
 function EMVU.Helper:GetIlluminationName( name, option )

--- a/lua/autorun/photon/sh_emv_helper.lua
+++ b/lua/autorun/photon/sh_emv_helper.lua
@@ -530,7 +530,7 @@ function EMVU.Helper:GetProps( name, ent )
 		end
 	end
 	if ent:Photon_PresetEnabled() then
-		local presetData = EMVU.Helper:GetPresetData( name, ent:Photon_ELPresetOption() )
+		local presetData = EMVU.Helper:GetPresetData( name, ent:Photon_ELPresetOption() ) or {}
 		if istable( presetData.Auto ) then
 			for _,id in pairs( presetData.Auto ) do
 				local preset = EMVU.AutoIndex[ name ][ id ]
@@ -618,7 +618,9 @@ function EMVU.Helper:BodygroupPreset( ent, index )
 end
 
 function EMVU.Helper:GetPresetData( name, index )
-	return EMVU.PresetIndex[ name ][ index ]
+	local presets = EMVU.PresetIndex[ name ]
+	if not presets then return {} end
+	return presets[ index ]
 end
 
 function EMVU.Helper:GetIlluminationName( name, option )

--- a/lua/autorun/photon/sh_emv_helper.lua
+++ b/lua/autorun/photon/sh_emv_helper.lua
@@ -530,7 +530,7 @@ function EMVU.Helper:GetProps( name, ent )
 		end
 	end
 	if ent:Photon_PresetEnabled() then
-		local presetData = EMVU.Helper:GetPresetData( name, ent:Photon_ELPresetOption() ) or {}
+		local presetData = EMVU.Helper:GetPresetData( name, ent:Photon_ELPresetOption() )
 		if istable( presetData.Auto ) then
 			for _,id in pairs( presetData.Auto ) do
 				local preset = EMVU.AutoIndex[ name ][ id ]


### PR DESCRIPTION
## Summary

`EMVU.Helper:GetPresetData` indexed `EMVU.PresetIndex[name][index]` unguarded, erroring when a vehicle has no preset index entry (or an invalid preset option). It now returns `{}` when either the name or the index is missing, so callers like `GetProps` can safely check `istable(presetData.Auto)`.

Cherry-picked from `claude/commit-breakdown-prs-c17a8c` (3 commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)