### PR TITLE
fix: Recreate EMVProps instead of duplicating them

### DIFF
--- a/lua/autorun/photon/cl_emv_meta.lua
+++ b/lua/autorun/photon/cl_emv_meta.lua
@@ -526,6 +526,13 @@ function EMVU:MakeEMV( emv, name )
 	function emv:Photon_SetupEMVProps()
 		if not IsValid( self ) then return false end
 		local emv = self
+
+		if istable( emv.EMVProps ) then
+			for _,prop in pairs( emv.EMVProps ) do
+				if prop and IsValid( prop ) then SafeRemoveEntity( prop ) end
+			end
+		end
+
 		local emvProps = EMVHelper:GetProps( self.VehicleName, self )
 		if emvProps then
 


### PR DESCRIPTION
## Summary

`Photon_SetupEMVProps` created a fresh set of client-side prop entities without checking whether `EMVProps` already existed, so repeated setup calls stacked duplicate props on the vehicle. It now removes any existing valid props (via `SafeRemoveEntity`) before recreating the set.

Cherry-picked from `claude/commit-breakdown-prs-c17a8c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)