### PR TITLE
fix: Suppress errors when spawning vehicles without tables

### DIFF
--- a/lua/autorun/photon/sh_emv_vehicles.lua
+++ b/lua/autorun/photon/sh_emv_vehicles.lua
@@ -43,6 +43,7 @@ end
 function EMVU:SpawnedVehicle( ent )
 	if not IsValid( ent ) then print( "[Photon] Tried to setup an invalid entity: " .. tostring(ent) ) end
 	local vehicleTable = Photon:GetVehicleTable( ent )
+	if not istable( vehicleTable ) then return end
 	local name = vehicleTable.Name
 	ent.Name = name
 	local vehicles = list.GetForEdit("Vehicles")


### PR DESCRIPTION
## Summary

`EMVU:SpawnedVehicle` dereferenced `vehicleTable.Name` unconditionally, erroring for vehicles that `Photon:GetVehicleTable` cannot resolve (e.g. spawned outside the Photon vehicle lists). It now returns early when no table is found.

Cherry-picked from `claude/commit-breakdown-prs-c17a8c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)