### PR TITLE
fix: Only put vehicles in the EMV vehicle table

### DIFF
--- a/lua/autorun/photon/sh_emv_init.lua
+++ b/lua/autorun/photon/sh_emv_init.lua
@@ -82,7 +82,7 @@ function EMVU:UpdateVehicles()
 	end
 
 	for _,ent in pairs( ents.GetAll() ) do
-		if IsValid( ent ) and ent.IsEMV and ent:IsEMV() then
+		if IsValid( ent ) and ent:IsVehicle() and ent.IsEMV and ent:IsEMV() then
 			emvVehicleTable[ #emvVehicleTable + 1 ] = ent
 		end
 	end


### PR DESCRIPTION
## Summary

`EMVU:UpdateVehicles` collected any entity with a truthy `IsEMV`, which can include non-vehicle entities (e.g. EMV props). The scan now also requires `ent:IsVehicle()` so only actual vehicles land in the EMV vehicle table.

Cherry-picked from `claude/commit-breakdown-prs-c17a8c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)