### PR TITLE
fix: Use VehicleName in DrawCarLights when set

### DIFF
--- a/lua/autorun/photon/cl_emv_init.lua
+++ b/lua/autorun/photon/cl_emv_init.lua
@@ -62,7 +62,14 @@ local function DrawCarLights()
 	for _, ent in pairs(Photon:AllVehicles() ) do
 		if IsValid(ent) and ent:Photon() then
 			if not ent.Photon_RenderLights then
-				Photon:SetupCar(ent, list.GetForEdit("Vehicles")[ent:GetVehicleClass()].Name)
+				local vname = ent.VehicleName
+				if not isstring(vname) or vname == "" then
+					local vdata = list.GetForEdit("Vehicles")[ent:GetVehicleClass()]
+					vname = vdata and vdata.Name
+				end
+				if vname then
+					Photon:SetupCar(ent, vname)
+				end
 			else
 				if should_render_reg:GetBool() then
 					ent:Photon_RenderLights(


### PR DESCRIPTION
## Summary

`DrawCarLights` resolved the setup name via `list.GetForEdit("Vehicles")[ent:GetVehicleClass()].Name` on every unlit vehicle, which errors when the vehicle class has no list entry. It now prefers the already-known `ent.VehicleName`, only falls back to the vehicle list, and skips setup entirely when no name can be resolved instead of erroring in the render hook.

Cherry-picked from `claude/commit-breakdown-prs-c17a8c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)