### PR TITLE
fix: Use EMVName as vehicle name recovery fallback

### DIFF
--- a/lua/autorun/photon/sh_photon_vehicles.lua
+++ b/lua/autorun/photon/sh_photon_vehicles.lua
@@ -53,6 +53,16 @@ function Photon:EntityCreated( ent )
 				end
 
 				if timer.RepsLeft( timerId ) == 0 and IsValid( ent ) and CLIENT then
+					local emvName = ent.EMVName and ent:EMVName()
+					if isstring(emvName) and emvName ~= "" then
+						ent.VehicleName = emvName
+						Photon:SpawnedVehicle( ent )
+						EMVU:SpawnedVehicle( ent )
+						timer.Stop( timerId )
+						timer.Destroy( timerId )
+						return
+					end
+
 					local base = ent.Base or ""
 					if not string.find(base, "glide") then
 						local class = ent:GetVehicleClass()


### PR DESCRIPTION
## Summary

When `Photon:EntityCreated`'s retry timer runs out of attempts to resolve a client-side vehicle name, it previously went straight to class-based recovery (`GetVehicleClass`). If the entity already has a networked `EMVName`, that is now used first: it sets `ent.VehicleName`, runs `Photon:SpawnedVehicle` / `EMVU:SpawnedVehicle`, and stops the timer.

Cherry-picked from `claude/commit-breakdown-prs-c17a8c`. Works with the existing `EMVName()` implementation; pairs naturally with #227 but does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)