### PR TITLE
fix: Off-by-one in SimpleNet mapping index bit width

### DIFF
--- a/lua/autorun/photon/shared/sh_simplenet.lua
+++ b/lua/autorun/photon/shared/sh_simplenet.lua
@@ -23,9 +23,16 @@ NET.INT = 2
 NET.UINT = 3
 NET.STR = 4
 
+--- Bit width for 1 based index of max value count.
+-- @int count Number of registered entries.
+-- @treturn int Bit width.
+local function IndexBits(count)
+	return math.max(1, math.ceil(math.log(count + 1, 2)))
+end
+
 NET.FMap = NET.FMap or {}
 NET.RMap = NET.RMap or {}
-NET.Bits = math.ceil(math.log(#NET.FMap, 2))
+NET.Bits = IndexBits(#NET.FMap)
 
 NET.WriteFunctions = {
 	[NET.BOOL] = net.WriteBool,
@@ -57,7 +64,7 @@ function NET:Map(name, netType, extra)
 		self.RMap[name][3] = extra
 	else
 		self.RMap[name] = {table.insert(self.FMap, {name, netType, extra}), netType, extra}
-		self.Bits = math.ceil(math.log(#self.FMap, 2))
+		self.Bits = IndexBits(#self.FMap)
 	end
 
 	if not self.WriteFunctions[netType] then


### PR DESCRIPTION
## Summary

`NET.Bits` was computed as `math.ceil(math.log(#NET.FMap, 2))`, which under-allocates for exact powers of two (e.g. 4 entries -> 2 bits, but index 4 needs 3 bits) and produces `-inf`/`0` for empty or single-entry maps. A new `IndexBits(count)` helper computes `max(1, ceil(log2(count + 1)))` and is used both at init and in `NET:Map`.

Cherry-picked from `claude/commit-breakdown-prs-c17a8c`. Touches a hunk of `sh_simplenet.lua` disjoint from #227, so both merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)