### PR TITLE
fix: Remove extra argument from SimpleNet Get wrappers

### DIFF
--- a/lua/autorun/photon/shared/sh_simplenet.lua
+++ b/lua/autorun/photon/shared/sh_simplenet.lua
@@ -74,11 +74,11 @@ function NET:Map(name, netType, extra)
 		end
 	end
 
-	self["Get" .. name] = function(env, ent, val, default)
-		return env:Get(ent, name, val, default)
+	self["Get" .. name] = function(env, ent, default)
+		return env:Get(ent, name, default)
 	end
-	ENT["Get" .. iName] = function(ent, val, default)
-		return self:Get(ent, name, val, default)
+	ENT["Get" .. iName] = function(ent, default)
+		return self:Get(ent, name, default)
 	end
 end
 


### PR DESCRIPTION
## Summary

The generated `Get*` wrappers passed `(ent, name, val, default)` into `NET:Get(ent, name, default)`, so the caller's intended default landed in the ignored fourth slot and `val` was treated as the default. The wrappers now take and forward `(ent, default)` only, matching `NET:Get`'s signature.

Cherry-picked from `claude/commit-breakdown-prs-c17a8c`. Touches a hunk of `sh_simplenet.lua` disjoint from #227 and #236, so all three merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)