### PR TITLE
feat: Add InterBenchmark trials for Photon hot paths

### DIFF
--- a/lua/internet_benchmark/trials/photon_color_alpha.lua
+++ b/lua/internet_benchmark/trials/photon_color_alpha.lua
@@ -1,0 +1,53 @@
+local base = Color(255, 128, 0, 255)
+local scratch = Color(255, 128, 0, 255)
+
+local colorAlpha = ColorAlpha
+local newColor = Color
+
+local out
+
+local function a()
+	out = colorAlpha(base, 128)
+end
+
+local function b()
+	out = newColor(base.r, base.g, base.b, 128)
+end
+
+local function c()
+	scratch.r = base.r
+	scratch.g = base.g
+	scratch.b = base.b
+	scratch.a = 128
+	out = scratch
+end
+
+local function d()
+	base.a = 128
+	out = base
+end
+
+TRIAL
+	:Name("Photon: Colour Alpha Derivation")
+	:Description(
+		"Photon derives a per-frame source colour from each light's base colour with ColorAlpha, allocating a new Color for "
+		.. "every visible light, every frame. This compares that against constructing the Color by hand, writing into a reused "
+		.. "scratch Color, and mutating the base colour's alpha in place."
+	)
+	:Order(203)
+	:Function(a)
+	:Label("ColorAlpha")
+	:Describe("What Photon currently does - a helper call that allocates a fresh Color each time.")
+	:Function(b)
+	:Label("Color()")
+	:Describe("The same allocation without the helper, reading the components out directly.")
+	:Function(c)
+	:Label("reused scratch")
+	:Describe("No allocation - but every consumer shares the same object, so it only works while nothing holds onto the previous value. Photon's render queue does, which is why it can't do this today.")
+	:Function(d)
+	:Label("mutate in place")
+	:Describe("The cheapest option and the most dangerous: the base colour is shared state, and anything else reading it now sees the modified alpha.")
+	:Before(function()
+		base.a = 255
+	end)
+	:Exclude("out")

--- a/lua/internet_benchmark/trials/photon_dynamic_accessors.lua
+++ b/lua/internet_benchmark/trials/photon_dynamic_accessors.lua
@@ -1,0 +1,56 @@
+local dir = Vector(1, 0, 0)
+
+local ent = {}
+function ent:GetForward()
+	return dir
+end
+
+local meta = {DirAxis = "Forward"}
+local axisMethod = "Get" .. meta.DirAxis
+local getForward = ent.GetForward
+
+local out
+
+local function a()
+	out = ent["Get" .. meta.DirAxis](ent)
+end
+
+local function b()
+	out = ent[axisMethod](ent)
+end
+
+local function c()
+	out = getForward(ent)
+end
+
+local function d()
+	out = ent:GetForward()
+end
+
+TRIAL
+	:Name("Photon: Dynamic Method Lookup")
+	:Description(
+		"Photon aims directional lights with parent[\"Get\" .. meta.DirAxis](parent), rebuilding the method name by string "
+		.. "concatenation on every call. This compares that against precomputing the name once, caching the method itself, "
+		.. "and a plain method call."
+	)
+	:Order(202)
+	:Function(a)
+	:Label("concat lookup")
+	:Describe("What Photon currently does - a string concatenation, a table lookup, and a call, every single time.")
+	:Function(b)
+	:Label("precomputed key")
+	:Describe("The method name built once outside the hot path, leaving just the lookup and the call.")
+	:Function(c)
+	:Label("cached method")
+	:Describe("The function itself captured as an upvalue, skipping the table lookup entirely.")
+	:Function(d)
+	:Label("direct method call")
+	:Describe("The baseline when the axis is known at write time and no dynamic dispatch is needed at all.")
+	:ManualPredefine(1, 10)
+	:Exclude("dir")
+	:Exclude("ent")
+	:Exclude("meta")
+	:Exclude("axisMethod")
+	:Exclude("getForward")
+	:Exclude("out")

--- a/lua/internet_benchmark/trials/photon_quarantined_dispatch.lua
+++ b/lua/internet_benchmark/trials/photon_quarantined_dispatch.lua
@@ -1,0 +1,44 @@
+local ent = {count = 0}
+
+local function process(e)
+	e.count = e.count + 1
+end
+
+local protectedCall = ProtectedCall
+local errorNoHalt = ErrorNoHaltWithStack
+
+local function a()
+	process(ent)
+end
+
+local function b()
+	pcall(process, ent)
+end
+
+local function c()
+	xpcall(process, errorNoHalt, ent)
+end
+
+local function d()
+	protectedCall(process, ent)
+end
+
+TRIAL
+	:Function(a)
+	:Label("direct call")
+	:Describe("No isolation at all - the dispatch cost every other variant is paying on top of, and the pattern where one bad entity takes the whole loop down.")
+	:Function(b)
+	:Label("pcall")
+	:Describe("Catches the error but discards the stack trace, leaving nothing to debug the broken vehicle with.")
+	:Function(c)
+	:Label("xpcall")
+	:Describe("The handler only runs when the call actually errors, so on the happy path this is paying for the extra argument, not the handler.")
+	:Function(d)
+	:Label("ProtectedCall")
+	:Describe("What Photon.RunQuarantined uses - errors are reported through the engine's error handler, with the full stack trace intact.")
+	:Before(function()
+		ent.count = 0
+	end)
+	:ManualPredefine(1, 5)
+	:Exclude("ent")
+	:Exclude("process")

--- a/lua/internet_benchmark/trials/photon_quarantined_dispatch.meta.lua
+++ b/lua/internet_benchmark/trials/photon_quarantined_dispatch.meta.lua
@@ -1,0 +1,11 @@
+-- ProtectedCall only exists inside Garry's Mod, and the function file
+-- captures it at include time.
+TRIAL
+	:Name("Photon: Quarantined Dispatch")
+	:Description(
+		"The call patterns available to Photon.RunQuarantined, which wraps per-entity scan and render callbacks so one vehicle with "
+		.. "broken data cannot kill a shared timer or repeat an error every frame: calling directly, pcall, xpcall with a "
+		.. "stack-reporting handler, and Garry's Mod's ProtectedCall."
+	)
+	:Order(201)
+	:If(ProtectedCall ~= nil)

--- a/lua/internet_benchmark/trials/photon_result_tables.lua
+++ b/lua/internet_benchmark/trials/photon_result_tables.lua
@@ -1,0 +1,58 @@
+local SLOTS = 31
+
+local reused = {}
+
+local out
+
+local function a(times)
+	local tab = {}
+	for i = 1, SLOTS do
+		tab[i] = times
+	end
+	out = tab
+end
+
+local function b(times)
+	local tab = {
+		true, true, true, true, true, true, true, true,
+		true, true, true, true, true, true, true, true,
+		true, true, true, true, true, true, true, true,
+		true, true, true, true, true, true, true
+	}
+	for i = 1, SLOTS do
+		tab[i] = times
+	end
+	out = tab
+end
+
+local function c(times)
+	for i = 1, SLOTS do
+		reused[i] = times
+	end
+	out = reused
+end
+
+TRIAL
+	:Name("Photon: Per-Light Result Tables")
+	:Description(
+		"Photon:PrepareVehicleLight builds a 31-slot render table for every visible light, every frame, by allocating a literal "
+		.. "prefilled with 31 trues and then overwriting the slots. This compares that against growing an empty table and against "
+		.. "reusing one table across calls."
+	)
+	:Order(200)
+	:Function(a)
+	:Label("fresh {}")
+	:Describe("A new empty table each call, grown one indexed write at a time - the array part reallocates as it grows.")
+	:Function(b)
+	:Label("prefilled literal")
+	:Describe("What Photon currently does: a literal of 31 trues sizes the array part in one go, at the cost of writing every slot twice.")
+	:Function(c)
+	:Label("reused table")
+	:Describe("One table shared across calls, so nothing is allocated at all - only safe when the consumer is done with the previous contents, which Photon's render queue is not.")
+	:Before(function()
+		reused = {}
+	end)
+	:ManualPredefine(1, 3)
+	:Exclude("SLOTS")
+	:Exclude("reused")
+	:Exclude("out")

--- a/lua/internet_benchmark/trials/photon_view_normals.lua
+++ b/lua/internet_benchmark/trials/photon_view_normals.lua
@@ -1,0 +1,57 @@
+local eyePos = Vector(90, -1408, 64)
+local lightPos = Vector(128, -1200, 96)
+
+local scratch = Vector()
+local newVector = Vector
+
+local out
+
+local function a()
+	local normal = lightPos - eyePos
+	normal:Normalize()
+	out = normal
+end
+
+local function b()
+	out = (lightPos - eyePos):GetNormalized()
+end
+
+local function c()
+	local normal = newVector(lightPos)
+	normal:Sub(eyePos)
+	normal:Normalize()
+	out = normal
+end
+
+local function d()
+	scratch:Set(lightPos)
+	scratch:Sub(eyePos)
+	scratch:Normalize()
+	out = scratch
+end
+
+TRIAL
+	:Name("Photon: View Normal Vectors")
+	:Description(
+		"Photon computes a view normal (light position minus eye position, normalised) for every visible light, every frame. "
+		.. "This compares the allocating forms - the subtraction operator and GetNormalized - against copy-then-mutate and "
+		.. "against reusing one scratch vector, which is what the engine does."
+	)
+	:Order(204)
+	:Function(a)
+	:Label("operator + Normalize")
+	:Describe("The subtraction operator allocates one new Vector, normalised in place afterwards.")
+	:Function(b)
+	:Label("GetNormalized")
+	:Describe("Two allocations per call: one from the subtraction, one from GetNormalized.")
+	:Function(c)
+	:Label("copy + in-place ops")
+	:Describe("One explicit copy, then mutating operations on it - the same allocation count as the operator form, spelled out.")
+	:Function(d)
+	:Label("reused scratch")
+	:Describe("What Photon's engine does - a module-local scratch vector mutated in place, allocating nothing per call.")
+	:ManualPredefine(1, 4)
+	:Exclude("eyePos")
+	:Exclude("lightPos")
+	:Exclude("scratch")
+	:Exclude("out")


### PR DESCRIPTION
## Summary

Ships five [InterBenchmark](https://github.com/JoshPiper/InterBenchmark) trials in `lua/internet_benchmark/trials/`. InterBenchmark discovers trials via `file.Find("internet_benchmark/trials/*.lua", "LUA")`, which spans all mounted addons, and its loader handles `AddCSLuaFile` itself — so this is purely additive: no changes to Photon's loaders, and the files are inert when InterBenchmark isn't installed. With both addons mounted, the trials appear in `internet_benchmark_run` reports at orders 200–204, after the suite's own trials.

Each trial benchmarks a pattern Photon actually runs per-light, per-frame (or per scan tick):

- **photon_result_tables** — the 31-slot render table `Photon:PrepareVehicleLight` allocates per visible light: the current prefilled-trues literal vs growing an empty table vs reusing one table.
- **photon_quarantined_dispatch** — the error-isolation cost behind `Photon.RunQuarantined`: direct call vs `pcall` vs `xpcall` vs `ProtectedCall`. Gated behind a `.meta.lua` `:If(ProtectedCall ~= nil)` so the function file is never included where it would error.
- **photon_dynamic_accessors** — the `parent["Get" .. meta.DirAxis](parent)` concat lookup in the light-angle code vs precomputed key, cached method, and direct call.
- **photon_color_alpha** — `ColorAlpha`'s per-light Color allocation vs manual construction, scratch reuse, and in-place mutation (aliasing caveats noted in the descriptions).
- **photon_view_normals** — per-light view-normal computation: allocating operator/`GetNormalized` forms vs the in-place scratch-vector approach `cl_photon_eng.lua` uses.

Trials follow the suite's conventions: `:Label`/`:Describe` per variant, `:Before` for state resets, `:Exclude` + `:ManualPredefine` for values the introspector can't serialise (line ranges verified against the introspection code), and cached-upvalue parity across variants so no comparison is skewed by global-lookup cost.

## Test plan

- [x] All six files parse clean under Lua 5.1 grammar (luaparse)
- [x] Builder API usage and meta-file gating verified against InterBenchmark's `sh_trial.lua` / `sh_core.lua`
- [ ] In-game smoke test: `internet_benchmark_run` with both addons mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)