### PR TITLE
ci: use app token for the app id and menu publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       -
         name: Release Please
@@ -41,7 +41,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       -
         name: Checkout


### PR DESCRIPTION
Two token fixes to the release pipeline, both needing the same new variable.

## ⚠️ Add the variable before merging

`actions/create-github-app-token@v3` deprecated `app-id` in favour of `client-id`, which warned on both jobs of the first Release Please run. An app's **Client ID** is a different identifier from its numeric **App ID**, so this cannot reuse `RELEASE_APP_ID`:

- Add `RELEASE_APP_CLIENT_ID` — the app's Client ID, shown next to App ID on the app's settings page (Settings → Developer settings → GitHub Apps → *your app*). It looks like `Iv23li...` rather than a number.

If this merges before that variable exists, `client-id` resolves empty and every token step fails. `app-id` still works today, so there is no rush. `RELEASE_APP_ID` becomes unused afterwards.

## Menu publishing

The `76.4.0` release did not publish its page to photonle/menu: the step was gated on a `MENU_REPO_TOKEN` secret that was never created, so it skipped silently. Since the app is already installed on photonle/menu, the changelog job now mints a token scoped to that repo instead:

```yaml
owner: photonle
repositories: menu
permission-contents: write
```

The secret and its `if:` gate are gone, so a missing installation now fails the job rather than skipping it — that silent skip is exactly why the page went unnoticed.

The generated menu page is also uploaded as a release asset now. Previously only `workshop.bbcode.txt` and `discord.md` were attached, so when the publish step skipped, the HTML was discarded with the runner and had to be regenerated by hand.

## Note

`76.4.0`'s page still needs publishing manually, since this only takes effect from the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
