### PR TITLE
ci: publish the menu page with the app token

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -69,9 +69,19 @@ jobs:
   changelog:
     name: Changelogs
     runs-on: ubuntu-latest
-    env:
-      MENU_TOKEN: ${{ secrets.MENU_REPO_TOKEN }}
     steps:
+      -
+        # Scoped to the menu repo, which the app is also installed on. Fails
+        # loudly if that installation goes away rather than skipping silently.
+        name: Mint Menu Token
+        id: menu-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: photonle
+          repositories: menu
+          permission-contents: write
       -
         name: Checkout
         uses: actions/checkout@v7
@@ -90,15 +100,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
+        # The menu page is uploaded too, so it survives even if publishing to the
+        # menu repo fails and can be copied across by hand.
         run: |
           gh release upload "${TAG}" \
             dist/workshop.bbcode.txt \
             dist/discord.md \
+            dist/*.html \
             --clobber
       -
         name: Publish to Menu
-        if: env.MENU_TOKEN != ''
         env:
+          MENU_TOKEN: ${{ steps.menu-token.outputs.token }}
           TAG: ${{ github.event.release.tag_name }}
         run: |
           version="${TAG#v}"


### PR DESCRIPTION
The `76.4.0` release did not publish its page to photonle/menu. The step was gated on a `MENU_REPO_TOKEN` secret that was never created, so it skipped silently.

Since the app is already installed on photonle/menu, the changelog job now mints a token scoped to that repo instead of reading a separate secret:

```yaml
owner: photonle
repositories: menu
permission-contents: write
```

The secret and its `if:` gate are both gone, so a missing installation now fails the job rather than skipping it. That silent skip is precisely why the missing page went unnoticed until it was asked about.

## The generated page is now a release asset

Only `workshop.bbcode.txt` and `discord.md` were being attached, so when the publish step skipped, the HTML was discarded with the runner. It is now uploaded alongside them, which means a failed publish leaves a recoverable artifact instead of nothing.

## Notes

- This follows #242 and needs no new setup — `RELEASE_APP_CLIENT_ID` is already in place.
- `76.4.0`'s page still needs publishing by hand, since this only takes effect from the next release. The regenerated file has been passed along separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
