### PR TITLE
ci: name releases after the photon series

### DIFF
--- a/.github/builder/changelog/build.mjs
+++ b/.github/builder/changelog/build.mjs
@@ -197,7 +197,8 @@ const version = tag.replace(/^v/i, '');
 // The menu site indexes updates by the two-part id (76.4), not the full semver.
 const shortVersion = version.match(/^(\d+\.\d+)/)?.[1] ?? version;
 const sections = parseBody(release.body);
-const title = release.name && release.name !== '' ? release.name : `Photon ${version}`;
+const named = Boolean(release.name && release.name !== '');
+const title = named ? release.name : `Photon ${version}`;
 
 if (sections.length === 0) {
 	console.warn('No changelog entries were parsed from the release body.');
@@ -206,7 +207,10 @@ if (sections.length === 0) {
 await mkdir(outDir, { recursive: true });
 await Promise.all([
 	writeFile(join(outDir, 'workshop.bbcode.txt'), buildWorkshop(sections, title)),
-	writeFile(join(outDir, 'discord.md'), buildDiscord(sections, `Photon ${tag || version}`, release.html_url)),
+	// Discord keeps the version alongside the title, since the announcement is
+	// read on its own without the release page for context. The fallback title
+	// already carries the version, so it is left alone.
+	writeFile(join(outDir, 'discord.md'), buildDiscord(sections, named && tag ? `${title} (${tag})` : title, release.html_url)),
 	writeFile(join(outDir, `${shortVersion}.html`), buildMenuPage(sections, {
 		title,
 		date: formatDate(release.published_at ?? release.created_at)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -85,6 +85,32 @@ jobs:
         if: steps.detect.outputs.release == 'true'
         run: awk '/^##[^#]/{n++} n==1' CHANGELOG.md > "${RUNNER_TEMP}/notes.md"
       -
+        # Titles read as the series name, with the update number appended for
+        # anything past the first release of that series: "Johnstown",
+        # "Johnstown Patch #4". A new series picks up its own name because the
+        # series is read from the addon rather than hardcoded here.
+        name: Compose Title
+        id: title
+        if: steps.detect.outputs.release == 'true'
+        env:
+          VERSION: ${{ steps.detect.outputs.version }}
+        run: |
+          series=$(sed -n 's/^PHOTON_SERIES = "\(.*\)"/\1/p' \
+            lua/autorun/photon/sh_emv_config.lua)
+          update=$(echo "${VERSION}" | cut -d. -f2)
+
+          if [ -z "$series" ]; then
+            echo "::warning::PHOTON_SERIES not found; falling back to the version."
+            title="v${VERSION}"
+          elif [ "$update" = "0" ]; then
+            title="${series}"
+          else
+            title="${series} Patch #${update}"
+          fi
+
+          echo "Release title: ${title}"
+          echo "title=${title}" >> "$GITHUB_OUTPUT"
+      -
         # Targeting the SHA rather than "master" keeps the tag correct even if
         # something else lands on master between the push and here.
         name: Create Release
@@ -92,10 +118,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.detect.outputs.version }}
+          TITLE: ${{ steps.title.outputs.title }}
         run: |
           gh release create "v${VERSION}" \
             --target "${GITHUB_SHA}" \
-            --title "v${VERSION}" \
+            --title "${TITLE}" \
             --notes-file "${RUNNER_TEMP}/notes.md"
       -
         # Mirrors release-please's own state model so the merged PR reads as


### PR DESCRIPTION
Release titles read as the series name, with the update number appended past the first release of a series. `v76.4.0` was titled from the bare version, which lost the naming style used by every earlier release ("Johnstown", "Johnstown Hotpatch").

| Version | Title |
|---|---|
| `76.0.0` | Johnstown |
| `76.1.0` | Johnstown Patch #1 |
| `76.4.0` | Johnstown Patch #4 |
| `76.12.0` | Johnstown Patch #12 |

The series is read from [sh_emv_config.lua](lua/autorun/photon/sh_emv_config.lua) rather than hardcoded, so a bump to series 77 picks up its new name with no workflow edit — the same file release-please already manages the version in. If `PHOTON_SERIES` cannot be read the title falls back to `v<version>` and logs a warning, so a rename or refactor there degrades rather than producing a title like "Patch #4" with no series.

## Discord now uses the title too

`build.mjs` was hardcoding `## Photon v76.4.0` and ignoring the release name entirely, while the Workshop and menu outputs used it — an inconsistency on my part. All three now agree:

- Menu page: `name: 'Johnstown Patch #4'`
- Workshop: `[h1]Johnstown Patch #4[/h1]`
- Discord: `## Johnstown Patch #4 (v76.4.0)`

Discord keeps the version in brackets because announcements are read on their own without the release page for context. When a release has no name at all, the fallback title already carries the version, so the tag is not appended twice.

## Verification

Title composition was run against `76.0.0`, `76.1.0`, `76.4.0`, `76.12.0`, `77.0.0` and a file with `PHOTON_SERIES` removed. The changelog outputs were regenerated from the real `v76.4.0` release payload for both the named and unnamed cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
