### PR TITLE
fix: Quarantine broken vehicles instead of killing shared scan loops

### DIFF
--- a/lua/autorun/photon/cl_emv_init.lua
+++ b/lua/autorun/photon/cl_emv_init.lua
@@ -33,6 +33,16 @@ hook.Add("InitPostEntity", "Photon.ReadyEL", function()
 	photon_ready = true
 end)
 
+--- Render a single vehicle's Emergency and Illumination lighting.
+local function DrawVehicleEMVLights(v)
+	if v.Photon_RenderEL then
+		v:Photon_RenderEL()
+	end
+	if v.Photon_RenderIllum then
+		v:Photon_RenderIllum()
+	end
+end
+
 --- Render function to draw Emergency and Illumination lighting.
 local function DrawEMVLights()
 	if not photon_ready then return end
@@ -40,12 +50,40 @@ local function DrawEMVLights()
 
 	for k, v in pairs(EMVU:AllVehicles()) do
 		if IsValid(v) then
-			if v.Photon_RenderEL then
-				v:Photon_RenderEL()
-			end
-			if v.Photon_RenderIllum then
-				v:Photon_RenderIllum()
-			end
+			Photon.RunQuarantined(v, DrawVehicleEMVLights)
+		end
+	end
+end
+
+--- Render a single vehicle's running lights and run its prop/wheel scans.
+local function DrawVehicleCarLights(ent)
+	if not ent.Photon_RenderLights then
+		local vname = ent.VehicleName
+		if not isstring(vname) or vname == "" then
+			local vdata = list.GetForEdit("Vehicles")[ent:GetVehicleClass()]
+			vname = vdata and vdata.Name
+		end
+		if vname then
+			Photon:SetupCar(ent, vname)
+		end
+	else
+		if should_render_reg:GetBool() then
+			ent:Photon_RenderLights(
+				ent:Photon_HeadlightsOn(),
+				ent:Photon_IsRunning(),
+				ent:Photon_IsReversing(),
+				ent:Photon_IsBraking(),
+				ent:Photon_TurningLeft(),
+				ent:Photon_TurningRight(),
+				ent:Photon_Hazards(),
+				PHOTON_DEBUG
+			)
+		end
+		if ent:IsEMV() and ent.Photon_ScanEMVProps then
+			ent:Photon_ScanEMVProps()
+		end
+		if ent:Photon_WheelEnabled() and ent.Photon_ScanWheels then
+			ent:Photon_ScanWheels()
 		end
 	end
 end
@@ -55,43 +93,13 @@ local function DrawCarLights()
 	if not photon_ready then return end
 
 	Photon:ClearLightQueue()
-	local photonDebug = PHOTON_DEBUG
 
 	for _, ent in pairs(Photon:AllVehicles() ) do
 		if IsValid(ent) and ent:Photon() then
-			if not ent.Photon_RenderLights then
-				local vname = ent.VehicleName
-				if not isstring(vname) or vname == "" then
-					local vdata = list.GetForEdit("Vehicles")[ent:GetVehicleClass()]
-					vname = vdata and vdata.Name
-				end
-				if vname then
-					Photon:SetupCar(ent, vname)
-				end
-			else
-				if should_render_reg:GetBool() then
-					ent:Photon_RenderLights(
-						ent:Photon_HeadlightsOn(),
-						ent:Photon_IsRunning(),
-						ent:Photon_IsReversing(),
-						ent:Photon_IsBraking(),
-						ent:Photon_TurningLeft(),
-						ent:Photon_TurningRight(),
-						ent:Photon_Hazards(),
-						photonDebug
-					)
-				end
-				if ent:IsEMV() and ent.Photon_ScanEMVProps then
-					ent:Photon_ScanEMVProps()
-				end
-				if ent:Photon_WheelEnabled() and ent.Photon_ScanWheels then
-					ent:Photon_ScanWheels()
-				end
-			end
+			Photon.RunQuarantined(ent, DrawVehicleCarLights)
 		end
 	end
 end
-
 hook.Add( "PreRender", "Photon.RenderScan", function()
 	DrawCarLights()
 	DrawEMVLights()
@@ -152,16 +160,32 @@ local function PhotonManualWindFocus()
 end
 -- hook.Add( "PreRender", "Photon.ManualFocusCheck", function() PhotonManualWindFocus() end )
 
+--- Tick the radar on a single vehicle.
+local function RadarTickVehicle( emv )
+	if emv.Photon_RadarActive and emv:Photon_RadarActive() then emv:Photon_RadarTick() end
+end
+
 --- Render function to tick the radar.
 local function PhotonRadarScan()
 	if not photon_ready or not should_render:GetBool() then return end
 	for _, emv in pairs( EMVU:AllVehicles() ) do
-		if IsValid( emv ) and emv.Photon_RadarActive and emv:Photon_RadarActive() then emv:Photon_RadarTick() end
+		if IsValid( emv ) then Photon.RunQuarantined( emv, RadarTickVehicle ) end
 	end
 end
 hook.Add( "Tick", "Photon.RadarScan", function() PhotonRadarScan() end)
 
 local photon_pause = false
+
+--- Calculate light frames for a single vehicle.
+local function CalculateVehicleFrames( ent )
+	if ent.EMV and ent.HasPhotonELS and ent:HasPhotonELS() and (
+		(ent.Photon_Lights and ent:Photon_Lights()) or
+		(ent.Photon_TrafficAdvisor and ent:Photon_TrafficAdvisor()) or
+		(ent.Photon_Illumination and ent:Photon_Illumination())
+	) then
+		ent:Photon_CalculateELFrames()
+	end
+end
 
 --- Timer to update frame calculations.
 function EMVU:CalculateFrames()
@@ -169,13 +193,7 @@ function EMVU:CalculateFrames()
 	if photon_pause then return end
 	if not should_render:GetBool() then return end
 	for _,ent in pairs( EMVU:AllVehicles() ) do
-		if IsValid(ent) and ent.EMV and ent.HasPhotonELS and ent:HasPhotonELS() and (
-			(ent.Photon_Lights and ent:Photon_Lights()) or
-			(ent.Photon_TrafficAdvisor and ent:Photon_TrafficAdvisor()) or
-			(ent.Photon_Illumination and ent:Photon_Illumination())
-		) then
-			ent:Photon_CalculateELFrames()
-		end
+		if IsValid( ent ) then Photon.RunQuarantined( ent, CalculateVehicleFrames ) end
 	end
 end
 timer.Create("EMVU.CalculateFrames", .03, 0, function()
@@ -448,14 +466,11 @@ local function getPhotonRotationEnts()
 	return _rotationEntCache
 end
 
---- Run bone rotation.
-Photon.BoneRotation = function()
-	if photon_pause then return end
-	for _,ent in pairs( getPhotonRotationEnts() ) do
-		if not IsValid(ent) then return end
-		if ent.PhotonRotationEnabled then
+--- Run bone rotation on a single rotating component entity.
+local function RotateComponentBones( ent )
+	if ent.PhotonRotationEnabled then
 			local emv = ent:GetParent()
-			if not IsValid( emv ) or not emv.Photon_LightOptionID then continue end
+			if not IsValid( emv ) or not emv.Photon_LightOptionID then return end
 			local stageId = emv:Photon_LightOptionID()
 			local auxState = emv:Photon_AuxOptionID()
 			local illumStage = emv:Photon_IllumOptionID()
@@ -534,7 +549,14 @@ Photon.BoneRotation = function()
 					ent:ManipulateBoneAngles( boneIndex, Angle( currentAngles.p, currentAngles.y, subAng ) )
 				end
 			end
-		end
+	end
+end
+
+--- Run bone rotation.
+Photon.BoneRotation = function()
+	if photon_pause then return end
+	for _,ent in pairs( getPhotonRotationEnts() ) do
+		if IsValid( ent ) then Photon.RunQuarantined( ent, RotateComponentBones ) end
 	end
 end
 

--- a/lua/autorun/photon/sh_photon_init.lua
+++ b/lua/autorun/photon/sh_photon_init.lua
@@ -41,6 +41,43 @@ if not Photon.Net then
 	end
 end
 
+--- Run an entity-processing callback, quarantining the entity if it errors.
+-- Errors inside timer callbacks permanently kill the timer and errors inside
+-- render hooks repeat every frame, so one vehicle with bad data must not be
+-- allowed to take a shared scan loop down with it. The offending entity is
+-- flagged and skipped on subsequent calls; the error itself is still reported
+-- through the engine error handler with a full stack trace.
+-- @ent ent Entity to process.
+-- @tparam function fn Callback, invoked as fn( ent ).
+-- @treturn bool If the callback ran without error.
+function Photon.RunQuarantined( ent, fn )
+	if ent.PhotonQuarantined then return false end
+
+	local ok = ProtectedCall( fn, ent )
+	if not ok then
+		ent.PhotonQuarantined = true
+		PhotonError( string.format(
+			"'%s' (%s) errored and has been disabled. Fix the vehicle/component data, then run photon_quarantine_reset to re-enable it.",
+			tostring( ent.VehicleName or ent.ComponentName or ent.Name or ent:GetClass() ),
+			tostring( ent )
+		) )
+	end
+
+	return ok
+end
+
+concommand.Add( "photon_quarantine_reset", function( ply )
+	if SERVER and IsValid( ply ) and not ply:IsAdmin() then return end
+	local count = 0
+	for _, ent in ipairs( ents.GetAll() ) do
+		if ent.PhotonQuarantined then
+			ent.PhotonQuarantined = nil
+			count = count + 1
+		end
+	end
+	PhotonWarning( string.format( "Re-enabled %d quarantined entities.", count ) )
+end )
+
 AddCSLuaFile("cl_photon_eng.lua")
 AddCSLuaFile("cl_photon_meta.lua")
 AddCSLuaFile("cl_photon_hooks.lua")

--- a/lua/autorun/photon/sv_photon_hooks.lua
+++ b/lua/autorun/photon/sv_photon_hooks.lua
@@ -1,13 +1,16 @@
 
-function Photon:RunningScan()
-	for k,v in pairs( self:AllVehicles() ) do
-		if IsValid( v ) and IsValid(v:GetDriver()) and v:GetDriver():IsPlayer() and v:Photon() then
-			if v:IsBraking() then v:CAR_Braking(true) else v:CAR_Braking(false) end
-			if v:IsReversing() then v:CAR_Reversing(true) else v:CAR_Reversing(false) end
-		end
+local function ScanRunningVehicle( v )
+	if IsValid( v:GetDriver() ) and v:GetDriver():IsPlayer() and v:Photon() then
+		if v:IsBraking() then v:CAR_Braking(true) else v:CAR_Braking(false) end
+		if v:IsReversing() then v:CAR_Reversing(true) else v:CAR_Reversing(false) end
 	end
 end
 
+function Photon:RunningScan()
+	for k,v in pairs( self:AllVehicles() ) do
+		if IsValid( v ) then Photon.RunQuarantined( v, ScanRunningVehicle ) end
+	end
+end
 hook.Add("PlayerEnteredVehicle", "Photon.EnterVeh.SGM", function(ply, v)
 	if IsValid(v) then
 		if v:Photon() then
@@ -57,9 +60,13 @@ end)
 timer.Create("Photon.RunScan", 0.5, 0, function()
 	Photon:RunningScan()
 end)
+
+local function ContinueVehicleSiren( car )
+	if car:HasPhotonELS() and car:ELS_Siren() then car:ELS_SirenContinue() end
+end
 timer.Create("Photon.SirenRunScan", 0.2, 0, function()
 	for _,car in pairs( Photon:AllVehicles() ) do
-		if car:HasPhotonELS() and car:ELS_Siren() then car:ELS_SirenContinue() end
+		if IsValid( car ) then Photon.RunQuarantined( car, ContinueVehicleSiren ) end
 	end
 end)
 
@@ -106,15 +113,18 @@ hook.Add( "Photon.CanPlayerModify", "Photon.DefaultModifyCheck", function( ply, 
 	end
 end )
 
+local function ScanVehicleUnitNumber( ent )
+	if not IsValid( ent:GetDriver() ) then return end
+	local ply = ent:GetDriver()
+	if ( ent:Photon_GetLiveryID() == "" and ( (not ent.PhotonUnitIDRequestTime) or ( RealTime() < ent.PhotonUnitIDRequestTime + 10 ) ) ) then
+		Photon.Net:RequestUnitNumber( ply )
+		ent.PhotonUnitIDRequestTime = RealTime()
+	end
+end
+
 local function PhotonUnitNumberScan()
 	for _,ent in pairs( EMVU:AllVehicles() ) do
-		if not IsValid( ent ) then continue end
-		if not IsValid( ent:GetDriver() ) then continue end
-		local ply = ent:GetDriver()
-		if ( ent:Photon_GetLiveryID() == "" and ( (not ent.PhotonUnitIDRequestTime) or ( RealTime() < ent.PhotonUnitIDRequestTime + 10 ) ) ) then
-			Photon.Net:RequestUnitNumber( ply )
-			ent.PhotonUnitIDRequestTime = RealTime()
-		end
+		if IsValid( ent ) then Photon.RunQuarantined( ent, ScanVehicleUnitNumber ) end
 	end
 end
 timer.Create( "Photon.UnitNumberScan", 2, 0, function()


### PR DESCRIPTION
Backported to `development` from `limelight-v3` (`54b8e45`).

Errors inside timer callbacks kill the timer permanently, and errors inside render hooks repeat every frame. Today a single vehicle with bad component data takes down light rendering for every vehicle on the server.

### Changes

**New primitive** — `Photon.RunQuarantined( ent, fn )` in `sh_photon_init.lua` wraps the callback in `ProtectedCall`. On error it flags `ent.PhotonQuarantined`, skips the entity on subsequent calls, and reports the failure via `PhotonError` naming the vehicle/component. The error still reaches the engine handler with a full stack trace. A `photon_quarantine_reset` concommand (admin-gated serverside) clears the flag and reports the count.

**Clientside loops** (`cl_emv_init.lua`) — five per-entity loop bodies extracted and dispatched through the wrapper: `DrawEMVLights`, `DrawCarLights`, `PhotonRadarScan`, `EMVU:CalculateFrames`, `Photon.BoneRotation`.

**Serverside loops** (`sv_photon_hooks.lua`) — three more: `Photon:RunningScan`, the `Photon.SirenRunScan` timer, and `PhotonUnitNumberScan`. The siren timer also gains an `IsValid` guard it previously lacked.

### Note for reviewers

Two things ride along that aren't purely mechanical:

- **Behaviour fix in `Photon.BoneRotation`.** The old loop used `if not IsValid(ent) then return end`, so one invalid entity aborted bone rotation for every *remaining* entity that frame. It's now a per-entity skip.
- `RotateComponentBones` retains the old body's indentation (still indented for the removed `for`/`if` nesting). Cosmetic, but it reads as misaligned — happy to reindent if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)