### PR TITLE
fix: Skip lossy matrix round-trip for pure-yaw auto anchors

### DIFF
--- a/lua/autorun/photon/sh_emv_vehicles.lua
+++ b/lua/autorun/photon/sh_emv_vehicles.lua
@@ -881,17 +881,7 @@ function EMVU:CalculateAuto( name, data, autoInsert )
 						end
 					end
 				else
-					local componentMatrix = Matrix()
-					componentMatrix:Translate(autoPos)
-					componentMatrix:Rotate(autoAng)
-					if not component.NotLegacy then
-						componentMatrix:Rotate(Angle(0, -90, 0))
-					end
-
 					local autoScaleVector = isvector(autoScale) and (autoScale) or Vector(autoScale, autoScale, autoScale)
-
-					local offsetMatrix = Matrix()
-					offsetMatrix:Translate(posData[1] * autoScaleVector)
 					local schmAngle = posData[2]
 					if component.ForwardTranslation then
 						schmAngle = Angle(
@@ -900,11 +890,42 @@ function EMVU:CalculateAuto( name, data, autoInsert )
 							schmAngle.p
 						)
 					end
-					offsetMatrix:Rotate(schmAngle)
-					local out = componentMatrix * offsetMatrix
 
-					newPos = out:GetTranslation()
-					newAng = out:GetAngles()
+					-- Matrix:GetAngles() decomposes pitch via atan2() against a non-negative
+					-- term, so it can never return |pitch| > 90 - it silently re-expresses
+					-- angles like the mirrored-component convention Angle(180-p, -y, 180-r)
+					-- as an equivalent rotation with a ~180 degree different yaw. That's fine
+					-- for anything reading Forward()/Right()/Up(), but PrepareVehicleLight's
+					-- lightNormal calc reads .y directly, so the swap flips the sprite to face
+					-- backwards.
+					-- Yaw is the outermost axis in Source's Euler convention, so a pure-yaw
+					-- anchor (no pitch/roll) composes with the component angle the same way
+					-- whether you add onto .y directly or go through the matrix - provably,
+					-- not just usually. That case can skip the lossy round-trip entirely.
+					-- Anchors with real pitch/roll don't have that guarantee: true composition
+					-- and naive addition genuinely diverge there, and nothing in the numbers
+					-- says which one a given component's angle was authored against.
+					if component.NotLegacy and autoAng.p == 0 and autoAng.r == 0 then
+						newPos = posData[1] * autoScaleVector
+						newPos:Rotate( Angle( 0, autoAng.y, 0 ) )
+						newPos:Add( autoPos )
+						newAng = Angle( schmAngle.p, schmAngle.y + autoAng.y, schmAngle.r )
+					else
+						local componentMatrix = Matrix()
+						componentMatrix:Translate(autoPos)
+						componentMatrix:Rotate(autoAng)
+						if not component.NotLegacy then
+							componentMatrix:Rotate(Angle(0, -90, 0))
+						end
+
+						local offsetMatrix = Matrix()
+						offsetMatrix:Translate(posData[1] * autoScaleVector)
+						offsetMatrix:Rotate(schmAngle)
+						local out = componentMatrix * offsetMatrix
+
+						newPos = out:GetTranslation()
+						newAng = out:GetAngles()
+					end
 				end
 
 				EMVU.Positions[ name ][ offset + id ] = {


### PR DESCRIPTION
Backported to `development` from `limelight-v3` (`1c000a3`).

`Matrix:GetAngles()` decomposes pitch through `atan2()` against a non-negative term, so it can never return `|pitch| > 90`. That silently re-expresses mirrored-component angles (`Angle(180-p, -y, 180-r)`) as an equivalent rotation with a ~180 degree different yaw.

That's harmless for anything reading `Forward()`/`Right()`/`Up()`, but `PrepareVehicleLight` reads `.y` directly when computing the light normal, so the swap flips the sprite to face backwards.

### Fix

Yaw is the outermost axis in Source's Euler convention, so composing a pure-yaw anchor (no pitch/roll) with a component's angle is provably identical whether done via matrix or plain addition. `EMVU:CalculateAuto` now takes a direct path in that case — rotate the offset by yaw, add yaw to the component angle — skipping the round-trip entirely.

Anchors with real pitch/roll still go through the original matrix path. True composition and naive addition genuinely diverge there, and nothing in the data says which convention a given component's angle was authored against.

### Verified against

FPIU16 wig-wag headlights and rear turn-signal hideaways, both of which pointed backwards before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)