### PR TITLE
chore: Increase the default fallback siren volume

### DIFF
--- a/lua/autorun/photon/sv_emv_meta.lua
+++ b/lua/autorun/photon/sv_emv_meta.lua
@@ -128,14 +128,14 @@ function EMVU:MakeEMV( ent, emv )
 			if EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume then
 				net.WriteFloat(EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume )
 			else
-				net.WriteFloat(75)
+				net.WriteFloat(90)
 			end
 		net.Broadcast()
 		self:SetNW2String("PhotonLE.Siren_Sound", sound)
 		if EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume then
 			self:SetNW2Float("PhotonLE.Siren_Volume", EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume )
 		else
-			self:SetNW2Float("PhotonLE.Siren_Volume", 75 )
+			self:SetNW2Float("PhotonLE.Siren_Volume", 90 )
 		end
 	end
 
@@ -153,14 +153,14 @@ function EMVU:MakeEMV( ent, emv )
 			if EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume then
 				net.WriteFloat(EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume )
 			else
-				net.WriteFloat(75)
+				net.WriteFloat(90)
 			end
 		net.Broadcast()
 		self:SetNW2String("PhotonLE.Siren2_Sound", sound)
 		if EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume then
 			self:SetNW2Float("PhotonLE.Siren_Volume", EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume )
 		else
-			self:SetNW2Float("PhotonLE.Siren_Volume", 75 )
+			self:SetNW2Float("PhotonLE.Siren_Volume", 90 )
 		end
 	end
 
@@ -178,14 +178,14 @@ function EMVU:MakeEMV( ent, emv )
 			if EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume then
 				net.WriteFloat(EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume )
 			else
-				net.WriteFloat(75)
+				net.WriteFloat(90)
 			end
 		net.Broadcast()
 		self:SetNW2String("PhotonLE.Manual_Sound", sound)
 		if EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume then
 			self:SetNW2Float("PhotonLE.Siren_Volume", EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume )
 		else
-			self:SetNW2Float("PhotonLE.Siren_Volume", 75 )
+			self:SetNW2Float("PhotonLE.Siren_Volume", 90 )
 		end
 	end
 
@@ -203,14 +203,14 @@ function EMVU:MakeEMV( ent, emv )
 			if EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume then
 				net.WriteFloat(EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume )
 			else
-				net.WriteFloat(75)
+				net.WriteFloat(85)
 			end
 		net.Broadcast()
 		self:SetNW2String("PhotonLE.Horn_Sound", sound)
 		if EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume then
 			self:SetNW2Float("PhotonLE.Siren_Volume", EMVU.GetSirenTable()[self:ELS_SirenSet()].Volume )
 		else
-			self:SetNW2Float("PhotonLE.Siren_Volume", 75 )
+			self:SetNW2Float("PhotonLE.Siren_Volume", 85 )
 		end
 	end
 


### PR DESCRIPTION
Backported to `development` from `limelight-v3` (`46b163e` + `ad2af44`, squashed — the second commit was a dropped closing paren on the manual-siren line, so there was no reason to carry both).

Raises the volume used when a siren set does not declare an explicit `Volume`:

| Sound | Before | After |
|---|---|---|
| Siren 1 | 75 | 90 |
| Siren 2 | 75 | 90 |
| Manual | 75 | 90 |
| Horn | 75 | 85 |

Applied to both the `net.WriteFloat` broadcast and the matching `NW2Float` in each branch so the two stay in sync.

Only affects siren sets with no explicit `Volume` — anything that declares one is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)