### PR TITLE
fix: guard against nil bone position in GetPositionFromRE

### DIFF
--- a/lua/autorun/photon/sh_emv_helper.lua
+++ b/lua/autorun/photon/sh_emv_helper.lua
@@ -675,6 +675,7 @@ function EMVU.Helper.GetPositionFromRE( car, lbEntity, posInput, returnWorld )
 	local boneData = EMVU.Auto[ tostring(lbEntity.ComponentName) ].Bones[ posData[2] ]
 	local boneIndex = boneData.Bone
 	local boneWorldPos, boneWorldAng = lbEntity:GetBonePosition( boneIndex )
+	if not boneWorldPos then return Vector(), Angle(), 0 end
 	-- local boneMatrix = lbEntity:GetBoneMatrix( )
 	-- local bonePos = car:WorldToLocal( boneWorldPos )
 	-- local boneAng = car:WorldToLocalAngles( boneWorldAng )


### PR DESCRIPTION
## Summary
- `EMVU.Helper.GetPositionFromRE` in `sh_emv_helper.lua` calls `lbEntity:GetBonePosition(boneIndex)` and feeds the result straight into `car:WorldToLocal(boneWorldPos)`. When the bone lookup fails, `GetBonePosition` returns `nil`, which crashes with `Vector expected, got nil`.
- Adds a guard that returns `Vector(), Angle(), 0` when `boneWorldPos` is nil, matching the fallback used elsewhere in this file.
- Ported from the unmerged `fix/detached-props` branch (2021), which had this fix but was never turned into a PR. Confirmed the branch's other two changes (prop reparenting on PVS re-entry, hook-ready ordering) are already handled differently in current `development`, so only this guard was still needed.

## Test plan
- [ ] Spawn an EMV vehicle whose lightbar/component bone data is missing or misnamed and confirm no crash occurs, position falls back to `Vector()/Angle()/0` instead.