### PR TITLE
fix: guard GetVehicleClass and hoist class variable in vehicle name recovery

### DIFF
--- a/lua/autorun/photon/sh_photon_vehicles.lua
+++ b/lua/autorun/photon/sh_photon_vehicles.lua
@@ -64,13 +64,14 @@ function Photon:EntityCreated( ent )
 					end
 
 					local base = ent.Base or ""
-					if not string.find(base, "glide") then
-						local class = ent:GetVehicleClass()
+					local class
+					if not string.find(base, "glide") and ent.GetVehicleClass then
+						class = ent:GetVehicleClass()
 					else
-						local class = ent:GetClass()
+						class = ent:GetClass()
 					end
 
-					local lst = list.GetForEdit("Vehicles")[class]
+					local lst = class and list.GetForEdit("Vehicles")[class]
 					if lst and istable(lst) then
 						ent.VehicleName = class
 						Photon:SpawnedVehicle( ent )


### PR DESCRIPTION
## Problem

```
lua/autorun/photon/sh_photon_vehicles.lua: attempt to call method 'GetVehicleClass' (a nil value)
```

Two bugs in the client-side fallback inside `Photon:EntityCreated`:

1. **`class` was always nil.** It was declared with `local` *inside* both branches of the `if/else`, so both declarations went out of scope at `end`. The `list.GetForEdit("Vehicles")[class]` lookup below therefore always indexed with `nil`, and the fallback path never resolved a vehicle name.
2. **`GetVehicleClass` was called unguarded.** Entities that don't define the method (e.g. Glide vehicles that don't match the `base` string check, or other non-standard vehicle bases) error out. `Photon:RecoverVehicleName` already guards this call the same way; this path did not.

## Fix

- Declare `class` once in the enclosing scope so the assignment survives the branch.
- Gate the `ent:GetVehicleClass()` call on `ent.GetVehicleClass` existing, falling back to `ent:GetClass()`.
- Skip the `Vehicles` list lookup entirely when no class was resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
