### PR TITLE
perf: Use xpcall instead of ProtectedCall for quarantined dispatch

### DIFF
--- a/lua/autorun/photon/sh_photon_init.lua
+++ b/lua/autorun/photon/sh_photon_init.lua
@@ -46,14 +46,16 @@ end
 -- render hooks repeat every frame, so one vehicle with bad data must not be
 -- allowed to take a shared scan loop down with it. The offending entity is
 -- flagged and skipped on subsequent calls; the error itself is still reported
--- through the engine error handler with a full stack trace.
+-- with a full stack trace.
+-- xpcall is used rather than ProtectedCall because the latter benchmarks ~6.3x
+-- slower per dispatch (296ns vs 47ns) and this runs per-entity, per-frame.
 -- @ent ent Entity to process.
 -- @tparam function fn Callback, invoked as fn( ent ).
 -- @treturn bool If the callback ran without error.
 function Photon.RunQuarantined( ent, fn )
 	if ent.PhotonQuarantined then return false end
 
-	local ok = ProtectedCall( fn, ent )
+	local ok = xpcall( fn, ErrorNoHaltWithStack, ent )
 	if not ok then
 		ent.PhotonQuarantined = true
 		PhotonError( string.format(

--- a/lua/internet_benchmark/trials/photon_quarantined_dispatch.lua
+++ b/lua/internet_benchmark/trials/photon_quarantined_dispatch.lua
@@ -32,10 +32,10 @@ TRIAL
 	:Describe("Catches the error but discards the stack trace, leaving nothing to debug the broken vehicle with.")
 	:Function(c)
 	:Label("xpcall")
-	:Describe("The handler only runs when the call actually errors, so on the happy path this is paying for the extra argument, not the handler.")
+	:Describe("What Photon.RunQuarantined uses - the handler only runs when the call actually errors, so on the happy path this is paying for the extra argument, not the handler.")
 	:Function(d)
 	:Label("ProtectedCall")
-	:Describe("What Photon.RunQuarantined uses - errors are reported through the engine's error handler, with the full stack trace intact.")
+	:Describe("Errors are reported through the engine's error handler, with the full stack trace intact, but the engine round-trip costs ~6x a plain Lua protected call.")
 	:Before(function()
 		ent.count = 0
 	end)


### PR DESCRIPTION
## Summary

The `photon_quarantined_dispatch` trial added in #248 measures `ProtectedCall` at **296ns/call against 47ns for `xpcall`** — 6.3x — while a direct call, `pcall` and `xpcall` all land within 2% of each other (i.e. within noise at this sample size).

`Photon.RunQuarantined` is called per-entity from render hooks (`DrawVehicleEMVLights`, `DrawVehicleCarLights`, `RotateComponentBones`, `CalculateVehicleFrames`) and from the server scan timers, so that overhead is paid every frame, per vehicle.

This swaps the implementation to `xpcall( fn, ErrorNoHaltWithStack, ent )`. The full stack trace — the reason `ProtectedCall` was picked in #245 — is preserved.

## Behavioural difference

`ProtectedCall` routes the error through the engine's error handler, so it reaches engine-level error reporting. `ErrorNoHaltWithStack` prints to console and fires `OnLuaError`, but is not an engine-side error. If anything downstream depends on the engine reporting path, this is the tradeoff to weigh; the quarantine flag plus the `PhotonError` message surfaces the offending entity either way.

## Test plan

- [ ] Re-run the `photon_quarantined_dispatch` trial to confirm the numbers above reproduce on another machine
- [ ] Spawn a vehicle with deliberately broken component data, confirm it is quarantined once and that the console shows a full stack trace
- [ ] Confirm `photon_quarantine_reset` still re-enables it

Benchmark numbers in this PR are taken from the trial report, not re-run as part of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
