### PR TITLE
fix: Illumination stage with no Lights table crashes ELS_IllumOn

### DIFF
--- a/lua/autorun/photon/sh_emv_helper.lua
+++ b/lua/autorun/photon/sh_emv_helper.lua
@@ -628,7 +628,9 @@ function EMVU.Helper:GetIlluminationName( name, option )
 end
 
 function EMVU.Helper:GetIlluminationLights( name, option )
-	return EMVU.Sequences[name].Illumination[option].Lights
+	local stageData = EMVU.Sequences[name].Illumination[option]
+	if not istable( stageData ) then return {} end
+	return stageData.Lights or {}
 end
 
 function EMVU.Helper:GetLampMeta( name, index )


### PR DESCRIPTION
## Summary
- `GetIlluminationLights` read `.Lights` off an illumination stage with no nil-guard and handed the result straight to `ipairs(...)` in `ELS_IllumOn`
- A custom vehicle config that defines an `Illumination` stage without a `Lights` array (e.g. a TKDN stage with no lamp positions) crashed the server-side illumination toggle for that car
- Now returns `{}` when the stage is missing or has no `Lights`, matching the guard pattern already used by `GetIllumSequence`/`GetPresetData` in the same file — a lamp-less stage just illuminates nothing instead of erroring

Fixes #220

## Test plan
- [ ] Load a vehicle whose `EMV.Sequences.Illumination` entry omits `Lights` and confirm toggling illumination (`X`) no longer throws `bad argument #1 to 'pairs'/'ipairs' (table expected, got nil)`
- [ ] Load a vehicle with a normal `Lights`-defined illumination stage and confirm takedown/alley lights still spawn as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)