### PR TITLE
fix: Prioritize explicit PI ref over PHOTON_INHERIT

### DIFF
--- a/lua/autorun/photon/sh_photon_vehicles.lua
+++ b/lua/autorun/photon/sh_photon_vehicles.lua
@@ -107,7 +107,7 @@ function Photon:LoadVehicles()
 	local cars = list.Get( "Vehicles" )
 	local found = false
 	for key,car in pairs(cars) do
-		if car.HasPhoton and car.Photon then
+		if car.HasPhoton and car.Photon and car.Photon != "PHOTON_INHERIT" then
 			found = true
 			Photon:PreloadVehicle( car )
 		elseif Photon:CheckForPhoton( car.Model ) then
@@ -116,6 +116,10 @@ function Photon:LoadVehicles()
 			car.Photon = Photon:CheckForPhoton( car.Model )
 			list.Set( "Vehicles", key, car )
 			Photon:PreloadVehicle( list.Get( "Vehicles" )[key] )
+		elseif car.HasPhoton and car.Photon then
+			-- PHOTON_INHERIT requested but no predefined Photon config exists for this model
+			found = true
+			Photon:PreloadVehicle( car )
 		end
 	end
 	if not found then


### PR DESCRIPTION
## Summary
- `Photon:LoadVehicles()` treated `"PHOTON_INHERIT"` as a valid explicit `Photon` value (a non-nil string), so it took the "already configured" branch and never reached the model-based predefined-PI lookup (`Photon:CheckForPhoton`).
- Vehicles declaring `HasPhoton = true, Photon = "PHOTON_INHERIT"` fell through to `PreloadVehicle`'s blank stub config instead of resolving a predefined PI (e.g. `sgm_fpiu20`), forcing users to name the PI explicitly instead of relying on inheritance.
- Fix: exclude `"PHOTON_INHERIT"` from the first branch so it falls through to the model lookup, and preserve the existing blank-stub fallback for models with no predefined PI.

Fixes #164

## Test plan
- [ ] In-game: register a vehicle with `HasPhoton = true, Photon = "PHOTON_INHERIT"` whose model has a predefined PI (e.g. `sgm_fpiu20`) and confirm the predefined PI config loads instead of a blank config.
- [ ] In-game: register a vehicle with `HasPhoton = true, Photon = "PHOTON_INHERIT"` whose model has no predefined PI and confirm it still falls back to the blank stub config without erroring.
- [ ] Confirm vehicles with an explicit `Photon = "sgm_fpiu20"`-style reference are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)