### PR TITLE
Add glualint CI workflow scoped to changed hunks

### DIFF
--- a/.github/scripts/lua_hunk_gate.py
+++ b/.github/scripts/lua_hunk_gate.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Runs glualint lint against changed .lua files, but only reports issues that fall on lines
+actually touched between --base and --head. Pre-existing issues elsewhere in a touched file are
+ignored so the gate doesn't block on legacy lint debt.
+"""
+import argparse
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+HUNK_HEADER_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+GITHUB_ANNOTATION_RE = re.compile(
+    r'^::(?P<level>error|warning) file=(?P<file>[^,]*),line=(?P<line>\d+),col=(?P<col>\d+),'
+    r'endLine=(?P<endLine>\d+),endColumn=(?P<endColumn>\d+),title="(?P<title>[^"]*)"::'
+    r'(?P<message>.*)$'
+)
+
+
+def sh(*args):
+    return subprocess.run(args, capture_output=True, text=True)
+
+
+def changed_lines_by_file(base, head):
+    """Returns {file: set(line numbers touched in the new version)} for *.lua files."""
+    diff = sh("git", "diff", "--unified=0", "--diff-filter=d", base, head, "--", "*.lua")
+    if diff.returncode != 0:
+        sys.exit(f"git diff {base}..{head} failed:\n{diff.stderr}")
+
+    result = defaultdict(set)
+    current_file = None
+    for line in diff.stdout.splitlines():
+        if line.startswith("+++ "):
+            path = line[4:]
+            current_file = None if path == "/dev/null" else path[2:]
+            continue
+        m = HUNK_HEADER_RE.match(line)
+        if m and current_file:
+            start = int(m.group(3))
+            count = int(m.group(4)) if m.group(4) is not None else 1
+            if count:
+                result[current_file].update(range(start, start + count))
+    return result
+
+
+def gate_lint(base, head):
+    changed = changed_lines_by_file(base, head)
+    files = sorted(changed)
+    if not files:
+        print("No changed .lua files to lint.")
+        return 0
+
+    proc = sh("glualint", "--output-format", "github", "lint", *files)
+
+    failed = False
+    for line in proc.stdout.splitlines():
+        m = GITHUB_ANNOTATION_RE.match(line)
+        if not m:
+            continue
+        touched = changed.get(m.group("file"), set())
+        span = range(int(m.group("line")), int(m.group("endLine")) + 1)
+        if not any(l in touched for l in span):
+            continue
+        print(line)
+        if m.group("level") == "error":
+            failed = True
+
+    if proc.returncode != 0 and not failed and proc.stderr.strip():
+        # glualint failed for a reason other than reportable lint messages (e.g. a parse
+        # error it couldn't attribute to a line range) - surface it rather than staying silent.
+        print(proc.stderr, file=sys.stderr)
+        failed = True
+
+    return 1 if failed else 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    args = parser.parse_args()
+
+    sys.exit(gate_lint(args.base, args.head))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/glualint.yml
+++ b/.github/workflows/glualint.yml
@@ -1,0 +1,57 @@
+name: GLua Lint
+
+on:
+  push:
+    paths:
+      - '**.lua'
+  pull_request:
+    paths:
+      - '**.lua'
+
+permissions:
+  contents: read
+
+jobs:
+  glualint:
+    name: glualint (changed hunks)
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      -
+        name: Determine Diff Range
+        id: diff-range
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+            if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+              # New branch or force-push with no known parent: diff against the empty tree so
+              # every line in every changed file is treated as touched.
+              base="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+            fi
+          fi
+          echo "base=${base}" >> "$GITHUB_OUTPUT"
+          echo "head=${head}" >> "$GITHUB_OUTPUT"
+      -
+        name: Install glualint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          asset_url=$(gh api repos/FPtje/GLuaFixer/releases/latest \
+            -q '.assets[] | select(.name | endswith("-x86_64-linux.zip")) | .browser_download_url')
+          curl --retry 3 --location "$asset_url" --output glualint.zip
+          unzip -q glualint.zip -d glualint-bin
+          install -m 755 glualint-bin/glualint /usr/local/bin/glualint
+      -
+        name: Lint Changed Hunks
+        run: |
+          python3 .github/scripts/lua_hunk_gate.py \
+            --base "${{ steps.diff-range.outputs.base }}" \
+            --head "${{ steps.diff-range.outputs.head }}"


### PR DESCRIPTION
## Summary
- Adds a `glualint` GitHub Actions workflow that runs on `push` and `pull_request` for `.lua` files.
- Only reports lint issues on lines actually touched by the diff, so pre-existing lint debt elsewhere in a modified file won't fail the build.
- Diff range is the PR base/head SHAs for pull requests, or the previous/current commit for pushes (falling back to the empty tree on a brand-new branch).

## Test plan
- [x] Verified the `glualint` release asset name/contents (`glualint-<version>-x86_64-linux.zip` → single `glualint` binary).
- [x] Unit-tested the GitHub-annotation regex and diff-hunk parsing against sample output.
- [x] Ran `changed_lines_by_file` against a real git repo diff and confirmed only the actually-changed lines are flagged.
- [ ] Not yet exercised against a live PR/push in this repo — first real run will validate the end-to-end path.