### PR TITLE
fix: isolate and validate siren files so one bad addon doesn't kill EMV init

### DIFF
--- a/lua/autorun/photon/library/emv_sirens.lua
+++ b/lua/autorun/photon/library/emv_sirens.lua
@@ -622,6 +622,15 @@ end
 EMVU.AddCustomSiren = function(index, siren)
 	if tonumber(index) ~= nil then return Error("[Photon] Custom sirens need a non-number identifier. See: https://github.com/photonle/Photon/wiki/Custom-Sirens\n") end
 
+	for _, existing in ipairs(sirenTable) do
+		if existing.ID == index then
+			return PhotonError(
+				"Custom siren '" .. tostring(index) .. "' uses an identifier that's already in use and has been skipped.\n",
+				"Choose a unique identifier. See: https://github.com/photonle/Photon/wiki/Custom-Sirens"
+			)
+		end
+	end
+
 	local valid, err = EMVU.ValidateSiren(siren)
 	if not valid then
 		return PhotonError(

--- a/lua/autorun/photon/library/emv_sirens.lua
+++ b/lua/autorun/photon/library/emv_sirens.lua
@@ -612,6 +612,10 @@ EMVU.ValidateSiren = function(siren)
 		if not isstring(tone.Sound) or tone.Sound == "" then return false, "Set[" .. i .. "] is missing required field 'Sound'" end
 	end
 
+	if siren.Horn ~= nil and (not isstring(siren.Horn) or siren.Horn == "") then return false, "optional field 'Horn' must be a non-empty string" end
+	if siren.Manual ~= nil and (not isstring(siren.Manual) or siren.Manual == "") then return false, "optional field 'Manual' must be a non-empty string" end
+	if siren.Volume ~= nil and not isnumber(siren.Volume) then return false, "optional field 'Volume' must be a number" end
+
 	return true
 end
 

--- a/lua/autorun/photon/library/emv_sirens.lua
+++ b/lua/autorun/photon/library/emv_sirens.lua
@@ -670,8 +670,17 @@ EMVU.AddCustomSiren("internets special siren number UNO", {
 ]]--
 
 EMVU.IncludeSiren = function(siren)
-	AddCSLuaFile("autorun/photon/library/sirens/" .. siren)
-	include("autorun/photon/library/sirens/" .. siren)
+	local path = "autorun/photon/library/sirens/" .. siren
+	AddCSLuaFile(path)
+
+	local ok, err = pcall(include, path)
+	if not ok then
+		PhotonError(
+			"Siren '" .. siren .. "' failed to load and has been skipped.\n",
+			"If you are the author, check your file for errors.\n",
+			tostring(err)
+		)
+	end
 end
 
 local sirens = file.Find("autorun/photon/library/sirens/*.lua", "LUA")

--- a/lua/autorun/photon/library/emv_sirens.lua
+++ b/lua/autorun/photon/library/emv_sirens.lua
@@ -673,7 +673,16 @@ EMVU.IncludeSiren = function(siren)
 	local path = "autorun/photon/library/sirens/" .. siren
 	AddCSLuaFile(path)
 
-	local ok, err = pcall(include, path)
+	local func = CompileFile(path)
+	if not func then
+		PhotonError(
+			"Siren '" .. siren .. "' failed to compile and has been skipped.\n",
+			"If you are the author, check your file for syntax errors (see the compile error above)."
+		)
+		return
+	end
+
+	local ok, err = pcall(func)
 	if not ok then
 		PhotonError(
 			"Siren '" .. siren .. "' failed to load and has been skipped.\n",

--- a/lua/autorun/photon/library/emv_sirens.lua
+++ b/lua/autorun/photon/library/emv_sirens.lua
@@ -596,8 +596,35 @@ EMVU.GetSirenTable = function()
 	return sirenTable
 end
 
+--- Checks a siren table for the fields required for it to work at runtime.
+-- @tparam table siren The siren table to check.
+-- @treturn bool Whether the siren is valid.
+-- @treturn string|nil A description of the first missing/invalid field, if any.
+EMVU.ValidateSiren = function(siren)
+	if not istable(siren) then return false, "siren must be a table" end
+	if not isstring(siren.Name) or siren.Name == "" then return false, "missing required field 'Name'" end
+	if not isstring(siren.Category) or siren.Category == "" then return false, "missing required field 'Category'" end
+	if not istable(siren.Set) or #siren.Set == 0 then return false, "missing required field 'Set' (must be a non-empty array of tones)" end
+
+	for i, tone in ipairs(siren.Set) do
+		if not istable(tone) then return false, "Set[" .. i .. "] must be a table" end
+		if not isstring(tone.Name) or tone.Name == "" then return false, "Set[" .. i .. "] is missing required field 'Name'" end
+		if not isstring(tone.Sound) or tone.Sound == "" then return false, "Set[" .. i .. "] is missing required field 'Sound'" end
+	end
+
+	return true
+end
+
 EMVU.AddCustomSiren = function(index, siren)
 	if tonumber(index) ~= nil then return Error("[Photon] Custom sirens need a non-number identifier. See: https://github.com/photonle/Photon/wiki/Custom-Sirens\n") end
+
+	local valid, err = EMVU.ValidateSiren(siren)
+	if not valid then
+		return PhotonError(
+			"Custom siren '" .. tostring(index) .. "' has an invalid format and has been skipped.\n",
+			err .. ". See: https://github.com/photonle/Photon/wiki/Custom-Sirens"
+		)
+	end
 
 	siren.ID = index
 	table.insert(sirenTable, siren)

--- a/lua/tests/photon/emv_add_custom_siren.lua
+++ b/lua/tests/photon/emv_add_custom_siren.lua
@@ -1,0 +1,40 @@
+return {
+	groupName = "EMVU.AddCustomSiren",
+
+	cases = {
+		{
+			name = "A valid custom siren is added to the siren table",
+			func = function(state)
+				local before = #EMVU.GetSirenTable()
+
+				EMVU.AddCustomSiren("gluatest_valid_siren", {
+					Name = "Example Siren",
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav", Icon = "wail"}
+					}
+				})
+
+				expect(#EMVU.GetSirenTable()).to.equal(before + 1)
+				expect(EMVU.GetSiren("gluatest_valid_siren").Name).to.equal("Example Siren")
+			end
+		},
+		{
+			name = "An invalid custom siren is rejected and logged instead of being added",
+			func = function(state)
+				local photonError = stub(_G, "PhotonError")
+				local before = #EMVU.GetSirenTable()
+
+				EMVU.AddCustomSiren("gluatest_invalid_siren", {
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav"}
+					}
+				})
+
+				expect(#EMVU.GetSirenTable()).to.equal(before)
+				expect(photonError).was.called()
+			end
+		}
+	}
+}

--- a/lua/tests/photon/emv_add_custom_siren.lua
+++ b/lua/tests/photon/emv_add_custom_siren.lua
@@ -35,6 +35,33 @@ return {
 				expect(#EMVU.GetSirenTable()).to.equal(before)
 				expect(photonError).was.called()
 			end
+		},
+		{
+			name = "A custom siren reusing an existing identifier is rejected and logged instead of being added",
+			func = function(state)
+				EMVU.AddCustomSiren("gluatest_duplicate_siren", {
+					Name = "First Siren",
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav"}
+					}
+				})
+
+				local photonError = stub(_G, "PhotonError")
+				local before = #EMVU.GetSirenTable()
+
+				EMVU.AddCustomSiren("gluatest_duplicate_siren", {
+					Name = "Second Siren",
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav"}
+					}
+				})
+
+				expect(#EMVU.GetSirenTable()).to.equal(before)
+				expect(EMVU.GetSiren("gluatest_duplicate_siren").Name).to.equal("First Siren")
+				expect(photonError).was.called()
+			end
 		}
 	}
 }

--- a/lua/tests/photon/emv_siren_validation.lua
+++ b/lua/tests/photon/emv_siren_validation.lua
@@ -1,0 +1,104 @@
+return {
+	groupName = "EMVU.ValidateSiren",
+
+	cases = {
+		{
+			name = "A siren with Name, Category and a Set of valid tones is valid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Name = "Example Siren",
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav", Icon = "wail"}
+					}
+				})
+
+				expect(valid).to.beTrue()
+				expect(err).to.beNil()
+			end
+		},
+		{
+			name = "A siren missing Name is invalid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav"}
+					}
+				})
+
+				expect(valid).to.beFalse()
+				expect(err).to.beA("string")
+			end
+		},
+		{
+			name = "A siren missing Category is invalid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Name = "Example Siren",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav"}
+					}
+				})
+
+				expect(valid).to.beFalse()
+				expect(err).to.beA("string")
+			end
+		},
+		{
+			name = "A siren missing Set is invalid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Name = "Example Siren",
+					Category = "Examples"
+				})
+
+				expect(valid).to.beFalse()
+				expect(err).to.beA("string")
+			end
+		},
+		{
+			name = "A siren with an empty Set is invalid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Name = "Example Siren",
+					Category = "Examples",
+					Set = {}
+				})
+
+				expect(valid).to.beFalse()
+				expect(err).to.beA("string")
+			end
+		},
+		{
+			name = "A siren with a tone missing Sound is invalid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Name = "Example Siren",
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL"}
+					}
+				})
+
+				expect(valid).to.beFalse()
+				expect(err).to.beA("string")
+			end
+		},
+		{
+			name = "A siren with a tone missing Name is invalid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Name = "Example Siren",
+					Category = "Examples",
+					Set = {
+						{Sound = "emv/sirens/example/example.wav"}
+					}
+				})
+
+				expect(valid).to.beFalse()
+				expect(err).to.beA("string")
+			end
+		}
+	}
+}

--- a/lua/tests/photon/emv_siren_validation.lua
+++ b/lua/tests/photon/emv_siren_validation.lua
@@ -99,6 +99,72 @@ return {
 				expect(valid).to.beFalse()
 				expect(err).to.beA("string")
 			end
+		},
+		{
+			name = "A siren with valid Horn, Manual and Volume fields is valid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Name = "Example Siren",
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav"}
+					},
+					Horn = "emv/sirens/example/horn.wav",
+					Manual = "emv/sirens/example/manual.wav",
+					Volume = 90
+				})
+
+				expect(valid).to.beTrue()
+				expect(err).to.beNil()
+			end
+		},
+		{
+			name = "A siren with a non-string Horn is invalid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Name = "Example Siren",
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav"}
+					},
+					Horn = 123
+				})
+
+				expect(valid).to.beFalse()
+				expect(err).to.beA("string")
+			end
+		},
+		{
+			name = "A siren with a non-string Manual is invalid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Name = "Example Siren",
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav"}
+					},
+					Manual = 123
+				})
+
+				expect(valid).to.beFalse()
+				expect(err).to.beA("string")
+			end
+		},
+		{
+			name = "A siren with a non-number Volume is invalid",
+			func = function(state)
+				local valid, err = EMVU.ValidateSiren({
+					Name = "Example Siren",
+					Category = "Examples",
+					Set = {
+						{Name = "WAIL", Sound = "emv/sirens/example/example.wav"}
+					},
+					Volume = "loud"
+				})
+
+				expect(valid).to.beFalse()
+				expect(err).to.beA("string")
+			end
 		}
 	}
 }

--- a/lua/tests/photon/emv_sirens.lua
+++ b/lua/tests/photon/emv_sirens.lua
@@ -1,0 +1,36 @@
+return {
+	groupName = "EMVU.IncludeSiren",
+
+	cases = {
+		{
+			name = "A siren file that errors on include is isolated and logged instead of aborting",
+			func = function(state)
+				stub(_G, "include").with(function(path)
+					error("bad syntax in " .. path)
+				end)
+				stub(_G, "AddCSLuaFile")
+				local photonError = stub(_G, "PhotonError")
+
+				expect(function()
+					EMVU.IncludeSiren("zz_broken_test_siren.lua")
+				end).to.succeed()
+
+				expect(photonError).was.called()
+			end
+		},
+		{
+			name = "A siren file that includes successfully is not reported as an error",
+			func = function(state)
+				stub(_G, "include").returns(true)
+				stub(_G, "AddCSLuaFile")
+				local photonError = stub(_G, "PhotonError")
+
+				expect(function()
+					EMVU.IncludeSiren("zz_working_test_siren.lua")
+				end).to.succeed()
+
+				expect(photonError).toNot.called()
+			end
+		}
+	}
+}

--- a/lua/tests/photon/emv_sirens.lua
+++ b/lua/tests/photon/emv_sirens.lua
@@ -3,10 +3,24 @@ return {
 
 	cases = {
 		{
-			name = "A siren file that errors on include is isolated and logged instead of aborting",
+			name = "A siren file that fails to compile is isolated and logged instead of aborting",
 			func = function(state)
-				stub(_G, "include").with(function(path)
-					error("bad syntax in " .. path)
+				stub(_G, "CompileFile").returns(nil)
+				stub(_G, "AddCSLuaFile")
+				local photonError = stub(_G, "PhotonError")
+
+				expect(function()
+					EMVU.IncludeSiren("zz_broken_test_siren.lua")
+				end).to.succeed()
+
+				expect(photonError).was.called()
+			end
+		},
+		{
+			name = "A siren file that compiles but errors on run is isolated and logged instead of aborting",
+			func = function(state)
+				stub(_G, "CompileFile").returns(function()
+					error("bad runtime code in siren file")
 				end)
 				stub(_G, "AddCSLuaFile")
 				local photonError = stub(_G, "PhotonError")
@@ -19,9 +33,9 @@ return {
 			end
 		},
 		{
-			name = "A siren file that includes successfully is not reported as an error",
+			name = "A siren file that compiles and runs successfully is not reported as an error",
 			func = function(state)
-				stub(_G, "include").returns(true)
+				stub(_G, "CompileFile").returns(function() end)
 				stub(_G, "AddCSLuaFile")
 				local photonError = stub(_G, "PhotonError")
 


### PR DESCRIPTION
## Summary
- A syntax error in a single custom siren file (e.g. `logies_sirens/whelenalphaold.lua`) previously propagated all the way up through `emv_sirens.lua` -> `sh_emv_init.lua` -> `emv_init.lua`, aborting the entire EMV init chain for every addon.
- `EMVU.IncludeSiren` now compiles each siren file with `CompileFile` and `pcall`s the compiled chunk, so both compile-time syntax errors and runtime errors are caught and logged with a clear `PhotonError`, instead of taking down the whole load.
- Added `EMVU.ValidateSiren`, a load-time format checker that verifies a siren table has the fields required to actually work (`Name`, `Category`, and a non-empty `Set` of tones, each with `Name`/`Sound`). `EMVU.AddCustomSiren` now rejects and logs malformed sirens instead of registering an entry that would error later when a player actually tries to play it.

## Test plan
- [x] Added GLuaTest coverage (`lua/tests/photon/emv_sirens.lua`) for `EMVU.IncludeSiren` isolating siren files that fail to compile, fail at runtime, or load successfully.
- [x] Added GLuaTest coverage (`lua/tests/photon/emv_siren_validation.lua`) for `EMVU.ValidateSiren` accepting well-formed sirens and rejecting ones missing required fields.
- [x] Added GLuaTest coverage (`lua/tests/photon/emv_add_custom_siren.lua`) for `EMVU.AddCustomSiren` adding valid sirens and rejecting/logging invalid ones without adding them to the siren table.
- [x] Drop a siren file with a deliberate syntax error into `lua/autorun/photon/library/sirens/` and confirm the rest of EMV/Photon still loads, with a `PhotonError` naming the broken file.