### PR TITLE
ci: Add GLuaTest workflow for PRs and development pushes

### DIFF
--- a/.github/workflows/gluatest.yml
+++ b/.github/workflows/gluatest.yml
@@ -1,0 +1,14 @@
+name: GLuaTest Runner
+
+on:
+  pull_request:
+  push:
+    branches:
+      - development
+
+jobs:
+  run-tests:
+    uses: CFC-Servers/GLuaTest/.github/workflows/run_tests.yml@main
+    with:
+      gamemode: sandbox
+      map: gm_construct

--- a/lua/tests/photon/main.lua
+++ b/lua/tests/photon/main.lua
@@ -1,0 +1,12 @@
+return {
+	groupName = "Photon Startup",
+
+	cases = {
+		{
+			name = "Photon global table is registered",
+			func = function(state)
+				expect(type(Photon)).to.equal("table")
+			end
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/gluatest.yml`, running CFC-Servers/GLuaTest's reusable workflow on pull requests and pushes to `development` (sandbox gamemode, gm_construct)
- Add a minimal smoke test at `lua/tests/photon/main.lua` verifying the `Photon` global table loads, so the workflow has something to validate

## Test plan
- [ ] Confirm the workflow run succeeds on this PR