### PR TITLE
perf: Trim per-light allocations in the render path

### DIFF
--- a/lua/autorun/photon/cl_photon_eng.lua
+++ b/lua/autorun/photon/cl_photon_eng.lua
@@ -52,6 +52,15 @@ local mat8 = Material("sprites/emv/dirty_lens_2")
 
 local up1 = Vector()
 
+-- Fixed corner rotations applied to dynamic light emission, indexed by emitDynamic.
+-- These are read-only: Rotate() mutates the vector being rotated, not the angle.
+local dynamicEmitRotations = {
+	Angle( 0, 135, 0 ),
+	Angle( 0, 45, 0 ),
+	Angle( 0, -135, 0 ),
+	Angle( 0, -45, 0 ),
+}
+
 local photonRenderTable = {}
 local photonDynamicLights = {}
 
@@ -146,10 +155,8 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 	if emitDynamic then
 			local addDynamic = { true, true, true, true }
 			local normalDir = parent:GetForward()
-			if emitDynamic == 1 then normalDir:Rotate( Angle( 0, 135, 0 ) )
-			elseif emitDynamic == 2 then normalDir:Rotate( Angle( 0, 45, 0 ) )
-			elseif emitDynamic == 3 then normalDir:Rotate( Angle( 0, -135, 0 ) )
-			elseif emitDynamic == 4 then normalDir:Rotate( Angle( 0, -45, 0 ) ) end
+			local emitRotation = dynamicEmitRotations[ emitDynamic ]
+			if emitRotation then normalDir:Rotate( emitRotation ) end
 			addDynamic[1] = worldPos
 			addDynamic[2] = normalDir
 			addDynamic[3] = { colors.raw.r, colors.raw.g, colors.raw.b }

--- a/lua/autorun/photon/cl_photon_eng.lua
+++ b/lua/autorun/photon/cl_photon_eng.lua
@@ -11,6 +11,7 @@ local useEyeAng = Angle( 0, 0, 0 )
 local useFovModifier = 1
 local istable = istable
 local isnumber = isnumber
+local isstring = isstring
 local pairs = pairs
 local ColorAlpha = ColorAlpha
 local Lerp = Lerp
@@ -29,6 +30,33 @@ if EMVU and istable( EMVU.Helper ) then
 	rotatingLight = EMVU.Helper.RotatingLight
 	pulsingLight = EMVU.Helper.PulsingLight
 	emvHelp = EMVU.Helper
+end
+
+local entityMeta = FindMetaTable( "Entity" )
+
+--- Resolves meta.DirAxis ( "Up", "Right", ... ) to its Entity getter and caches the result on
+-- the meta table, in the same way the sprite material and quad corners are cached further down.
+-- Rebuilding "Get" .. meta.DirAxis per light per frame was allocating a string every frame.
+-- An axis with no matching getter caches false, so a bad library definition is reported once
+-- instead of erroring out of the render path on every frame.
+local function resolveDirAxis( meta )
+	local resolved = meta.PhotonDirAxisGetter
+	if resolved ~= nil then return resolved end
+
+	if isstring( meta.DirAxis ) then
+		resolved = entityMeta[ "Get" .. meta.DirAxis ] or false
+	else
+		resolved = false
+	end
+
+	meta.PhotonDirAxisGetter = resolved
+
+	if not resolved then
+		ErrorNoHalt( "[Photon] Light meta has an unknown DirAxis (" .. tostring( meta.DirAxis ) ..
+			"); directional aiming will be skipped for it.\n" )
+	end
+
+	return resolved
 end
 
 local function getViewFlare( dot, brght )
@@ -174,12 +202,12 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 		ca:RotateAroundAxis( parent:GetUp(), ( lang.y + offset ) )
 	elseif contingent then
 		ca:RotateAroundAxis( parent:GetUp(), ( lang.r + 180 ) )
-	else
-		if meta.DirAxis and not rotating then
-			ca:RotateAroundAxis( parent["Get"..meta.DirAxis](parent), lang.r - meta.DirOffset )
-			ca:RotateAroundAxis( parent:GetUp(), lang.y )
-		elseif meta.DirAxis and rotating then
-			ca:RotateAroundAxis( parent["Get"..meta.DirAxis](parent), lang.r - meta.DirOffset - offset )
+	elseif meta.DirAxis then
+		local dirAxisGetter = resolveDirAxis( meta )
+		if dirAxisGetter then
+			local roll = lang.r - meta.DirOffset
+			if rotating then roll = roll - offset end
+			ca:RotateAroundAxis( dirAxisGetter( parent ), roll )
 			ca:RotateAroundAxis( parent:GetUp(), lang.y )
 		end
 	end

--- a/lua/autorun/photon/cl_photon_eng.lua
+++ b/lua/autorun/photon/cl_photon_eng.lua
@@ -161,7 +161,6 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 	if not meta.Scale then meta.Scale = 1 end
 	if not meta.WMult then meta.WMult = 1 end
 	local ca = parent:GetAngles()
-	local lightNormal = Angle()
 	if legacy and not contingent then
 		ca:RotateAroundAxis( parent:GetUp(), ( lang.y + offset ) )
 	elseif contingent then
@@ -175,7 +174,7 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 			ca:RotateAroundAxis( parent:GetUp(), lang.y )
 		end
 	end
-	lightNormal = ca:Forward()
+	local lightNormal = ca:Forward()
 	lightNormal:Normalize()
 
 	local ViewNormal = Vector()

--- a/lua/autorun/photon/cl_photon_eng.lua
+++ b/lua/autorun/photon/cl_photon_eng.lua
@@ -7,6 +7,8 @@ local pow = math.pow
 local round = math.Round
 local useEyePos = Vector( 0, 0, 0 )
 local useEyeAng = Angle( 0, 0, 0 )
+-- Refreshed once per frame alongside the eye info below, rather than per light.
+local useFovModifier = 1
 local istable = istable
 local isnumber = isnumber
 local pairs = pairs
@@ -215,7 +217,7 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 
 		viewDot = viewDot * brightness
 		local viewFlare = getViewFlare( viewPercent, brightness )
-		local dist = worldPos:Distance( EyePos() )
+		local dist = worldPos:Distance( useEyePos )
 		local distModifier = ( 1 - clamp( ( dist / 512 ), 0, 1) )
 		viewFlare = viewFlare * distModifier
 
@@ -267,9 +269,8 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 		if not meta.SprL then meta.SprL = Vector( meta.W * .5, -meta.H * .5, 0 ) end
 		resultTable[9] = meta.SprL
 		resultTable[10] = worldPos
-		local fovModifier = math.Clamp( ( ( 1 - ( LocalPlayer():GetFOV() / 90 ) ) * 5 ) + 1, 1, 1000 )
 		resultTable[11] = (meta.Scale * viewDot) * manualBloom
-		resultTable[12] = ((meta.Scale * viewFlare) * fovModifier) * manualBloom
+		resultTable[12] = ((meta.Scale * viewFlare) * useFovModifier) * manualBloom
 		resultTable[13] = (meta.Scale * meta.WMult*viewDot) * manualBloom
 		resultTable[14] = srcColor
 
@@ -573,9 +574,15 @@ end
 
 local EyePos = EyePos
 local EyeAngles = EyeAngles
+local LocalPlayer = LocalPlayer
 hook.Add( "PostDrawTranslucentRenderables", "Photon.UpdateLocalEyeInfo", function()
 	useEyePos:Set( EyePos() )
 	useEyeAng:Set( EyeAngles() )
+
+	local ply = LocalPlayer()
+	if IsValid( ply ) then
+		useFovModifier = clamp( ( ( 1 - ( ply:GetFOV() / 90 ) ) * 5 ) + 1, 1, 1000 )
+	end
 end)
 
 -- concommand.Add( "photon_maxoverride", function( ply )

--- a/lua/autorun/photon/cl_photon_eng.lua
+++ b/lua/autorun/photon/cl_photon_eng.lua
@@ -122,7 +122,6 @@ end
 
 function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, pixvis, lnum, brght, multicolor, type, emitDynamic, contingent )
 	if not incolors or not ilpos or not lang or not meta or not gpos then return end
-	local resultTable = { true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true }
 	local legacy = true
 	if meta.NoLegacy == true then legacy = false end
 	local colors = incolors
@@ -288,6 +287,8 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 
 		if PHOTON_DEBUG and !PHOTON_DEBUG_EXCLUSIVE then srcColor = Color( 255, 255, 0, 255 ) elseif PHOTON_DEBUG and PHOTON_DEBUG_EXCLUSIVE then srcColor = Color( 0, 0, 0, 0 ) end
 		if PHOTON_DEBUG and PHOTON_DEBUG_LIGHT and lpos == PHOTON_DEBUG_LIGHT[1] then srcColor = Color( 0, 255, 255 ) end
+
+		local resultTable = { true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true }
 
 		resultTable[1] = srcOnly
 		resultTable[2] = !srcSkip


### PR DESCRIPTION
Addresses part of §5.2 of the codebase review ("Per-frame garbage in the render path"). This is the first of four stacked PRs; it holds the changes that stand on their own and carry no aliasing risk.

`Photon:PrepareVehicleLight` runs once per light per frame — roughly 50 lights per lit vehicle at 60+ fps — so anything it allocates is megabytes per second of garbage and shows up as GC hitching.

### Commits

- **Drop dead Angle allocation for lightNormal** — the angle was allocated and then unconditionally overwritten with `ca:Forward()` without ever being read.
- **Hoist per-frame view state out of the per-light path** — the FOV modifier called `LocalPlayer():GetFOV()` per light, and distance measured against a fresh `EyePos()` even though the file already keeps `useEyePos` for exactly this. Both now come from the existing `Photon.UpdateLocalEyeInfo` hook.
- **Hoist constant dynamic-emit rotations to module scope** — four fixed `Angle`s were rebuilt per light; they are now a lookup table indexed by `emitDynamic`.
- **Resolve DirAxis to its Entity getter once per light meta** — `parent["Get" .. meta.DirAxis](parent)` rebuilt the method name by string concatenation on every light on every frame.
- **Only allocate the result table for lights that are drawn** — the 31-slot table was allocated before the visibility and view-dot tests that reject most lights on most frames.

### Measured

From the InterBenchmark suite (`Photon: Dynamic Method Lookup`, report of 2026-08-14, LuaJIT 2.1.0-beta3, Ryzen 7 5800X):

| candidate | per call | vs fastest |
|---|---|---|
| `ent[axisMethod](ent)` — precomputed key | 47.32ns | 100% |
| `getForward(ent)` — cached method **(this PR)** | 47.67ns | 101% |
| `ent:GetForward()` — direct call | 48.11ns | 102% |
| `ent["Get" .. meta.DirAxis](ent)` — **what this replaces** | 62.14ns | 131% |

The win is dropping the concatenation: ~24% off that call. Which of the three remaining forms is used does not matter — they span 47.32–48.11ns, well inside the suite's own <5% tie threshold. This PR caches the method itself because that also gives a place to detect an unresolvable axis once.

### Review notes

- The FOV and eye position are now one frame stale. The eye position already was — `PostDrawTranslucentRenderables` runs after `PreRender`, where the queue is built — so this makes the distance calculation *consistent* with the view normal a few lines above it, which was already reading the cached position.
- One deliberate behaviour change: a light meta with a `DirAxis` that has no matching Entity getter used to call a nil value and error out of the render path every frame. It now reports once, caches the failure, and skips directional aiming for that meta. Nothing in `library/auto/` currently has a bad axis (they are all `Up` or `Right`), so this only affects malformed third-party components.
- The rotating and non-rotating `DirAxis` branches were identical apart from subtracting the rotation offset from the roll, so they collapse into one.

### Testing

`glualint` is clean on every touched line (the repo's hunk gate passes). This is client-side render code, so it is not reachable from the GLuaTest suite — it still wants an in-game pass with a lit vehicle, including one rotating-light vehicle to exercise the `DirAxis`/offset path.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
