### PR TITLE
perf: Pool the light render queues

### DIFF
--- a/lua/autorun/photon/cl_photon_eng.lua
+++ b/lua/autorun/photon/cl_photon_eng.lua
@@ -289,8 +289,6 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 
 		if (meta.Sprite and meta.Sprite == "sprites/emv/blank") or meta.Cheap then srcSkip = true end
 
-		local UC = { true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true }
-
 		local brightness = 1
 		local rawBrightness = 1
 		local pulseOverride = false
@@ -323,10 +321,6 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 		up1:Set( worldPos )
 		local ua = parent:LocalToWorldAngles( al )
 
-		for k,v in pairs( colors ) do
-			UC[k] = v
-		end
-
 		local resultTable = acquireLightEntry()
 
 		-- The source colour belongs to the pooled entry, so it is rewritten in place instead
@@ -335,15 +329,15 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 		writeColor( srcColor, 255, 255, 255, 255 )
 
 		if not srcSkip then
-			//srcColor = ColorAlpha( UC.src, UC.src.a * rawBrightness )
-			local src = UC.src
+			//srcColor = ColorAlpha( colors.src, colors.src.a * rawBrightness )
+			local src = colors.src
 			srcColor.r = src.r
 			srcColor.g = src.g
 			srcColor.b = src.b
 			if pulseOverride then srcColor.a = ( srcColor.a * brightness ) end
-			if istable(UC["dim"]) then
+			if istable(colors["dim"]) then
 				local srcMod = ( viewDot * .5 ) * manualBloom
-				local dim = UC.dim
+				local dim = colors.dim
 				srcColor.r = Lerp( srcMod, dim.r, src.r )
 				srcColor.g = Lerp( srcMod, dim.g, src.g )
 				srcColor.b = Lerp( srcMod, dim.b, src.b )
@@ -373,12 +367,12 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 		resultTable[13] = (meta.Scale * meta.WMult*viewDot) * manualBloom
 		resultTable[14] = srcColor
 
-		resultTable[15] = UC.med
-		resultTable[16] = UC.amb
-		resultTable[17] = UC.blm
-		resultTable[18] = UC.glw
-		resultTable[19] = UC.raw
-		resultTable[20] = UC.flr
+		resultTable[15] = colors.med
+		resultTable[16] = colors.amb
+		resultTable[17] = colors.blm
+		resultTable[18] = colors.glw
+		resultTable[19] = colors.raw
+		resultTable[20] = colors.flr
 
 		resultTable[21] = lightMod
 		resultTable[22] = cheapLight

--- a/lua/autorun/photon/cl_photon_eng.lua
+++ b/lua/autorun/photon/cl_photon_eng.lua
@@ -34,6 +34,14 @@ end
 
 local entityMeta = FindMetaTable( "Entity" )
 
+--- Overwrites a colour in place, for colours owned by a pooled render queue entry.
+local function writeColor( color, r, g, b, a )
+	color.r = r
+	color.g = g
+	color.b = b
+	color.a = a
+end
+
 --- Resolves meta.DirAxis ( "Up", "Right", ... ) to its Entity getter and caches the result on
 -- the meta table, in the same way the sprite material and quad corners are cached further down.
 -- Rebuilding "Get" .. meta.DirAxis per light per frame was allocating a string every frame.
@@ -89,8 +97,15 @@ local dynamicEmitRotations = {
 	Angle( 0, -45, 0 ),
 }
 
+-- Both queues are rebuilt from scratch every frame, so their entries are pooled rather than
+-- reallocated: ClearLightQueue rewinds the counts below and the next frame overwrites the
+-- entries in place. Entries past the current count are retained deliberately - they are the
+-- pool. Anything an entry owns mutably (its source colour, its emit positions) is allocated
+-- once with the entry and rewritten per frame.
 local photonRenderTable = {}
+local photonRenderCount = 0
 local photonDynamicLights = {}
+local photonDynamicCount = 0
 
 hook.Add( "InitPostEntity", "Photon.AddHelperLocalVars", function()
 	rotatingLight = EMVU.Helper.RotatingLight
@@ -108,16 +123,53 @@ end)
 
 
 function Photon:AddLightToQueue( lightInfo )
-	photonRenderTable[ #photonRenderTable + 1 ] = lightInfo
+	photonRenderCount = photonRenderCount + 1
+	photonRenderTable[ photonRenderCount ] = lightInfo
 end
 
 function Photon.AddDynamicLightToQueue( lightInfo )
-	photonDynamicLights[ #photonDynamicLights + 1 ] = lightInfo
+	photonDynamicCount = photonDynamicCount + 1
+	photonDynamicLights[ photonDynamicCount ] = lightInfo
 end
 
 function Photon:ClearLightQueue()
-	table.Empty( photonRenderTable )
-	table.Empty( photonDynamicLights )
+	photonRenderCount = 0
+	photonDynamicCount = 0
+end
+
+--- Claims the next render queue entry, building it on first use.
+-- Slot 14 holds the source colour and slot 24 the rotated emit positions; both are owned by
+-- the entry and rewritten in place, so neither is reallocated once the pool has grown to the
+-- frame's light count.
+local function acquireLightEntry()
+	photonRenderCount = photonRenderCount + 1
+
+	-- AddLightToQueue is public, so a caller outside Photon may have parked its own table at
+	-- this index. Anything without the pooled layout is replaced rather than written into.
+	local entry = photonRenderTable[ photonRenderCount ]
+	if not entry or not entry.emitPositions then
+		entry = { true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true }
+		entry[14] = Color( 255, 255, 255, 255 )
+		entry[24] = false
+		entry.emitPositions = { n = 0 }
+		photonRenderTable[ photonRenderCount ] = entry
+	end
+
+	return entry
+end
+
+--- Claims the next dynamic light queue entry, building it on first use.
+-- Slot 3 is the entry's own { r, g, b } triple, rewritten per frame.
+local function acquireDynamicEntry()
+	photonDynamicCount = photonDynamicCount + 1
+
+	local entry = photonDynamicLights[ photonDynamicCount ]
+	if not entry or not istable( entry[3] ) then
+		entry = { true, true, { 0, 0, 0 }, 0 }
+		photonDynamicLights[ photonDynamicCount ] = entry
+	end
+
+	return entry
 end
 
 function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, pixvis, lnum, brght, multicolor, type, emitDynamic, contingent )
@@ -180,16 +232,20 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 	if EMV_DEBUG then viewDot = 1 end
 
 	if emitDynamic then
-			local addDynamic = { true, true, true, true }
 			local normalDir = parent:GetForward()
 			local emitRotation = dynamicEmitRotations[ emitDynamic ]
 			if emitRotation then normalDir:Rotate( emitRotation ) end
+
+			local addDynamic = acquireDynamicEntry()
+			local rawColor = colors.raw
+			local dynamicColor = addDynamic[3]
+			dynamicColor[1] = rawColor.r
+			dynamicColor[2] = rawColor.g
+			dynamicColor[3] = rawColor.b
 			addDynamic[1] = worldPos
 			addDynamic[2] = normalDir
-			addDynamic[3] = { colors.raw.r, colors.raw.g, colors.raw.b }
 			addDynamic[4] = ( parent:EntIndex() * 400 ) + emitDynamic
 			-- addDynamic[4] = (parent:EntIndex()*100) + ( lnum * 4 )
-			Photon.AddDynamicLightToQueue( addDynamic )
 		end
 
 	if not visible or visible <= 0 then return end
@@ -271,24 +327,31 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 			UC[k] = v
 		end
 
-		local srcColor = Color(255,255,255,255)
+		local resultTable = acquireLightEntry()
+
+		-- The source colour belongs to the pooled entry, so it is rewritten in place instead
+		-- of being rebuilt. It starts opaque white, matching the old default.
+		local srcColor = resultTable[14]
+		writeColor( srcColor, 255, 255, 255, 255 )
 
 		if not srcSkip then
-			local srcMod = ( viewDot * .5 ) * manualBloom
 			//srcColor = ColorAlpha( UC.src, UC.src.a * rawBrightness )
-			srcColor = ColorAlpha( UC.src, 255 )
+			local src = UC.src
+			srcColor.r = src.r
+			srcColor.g = src.g
+			srcColor.b = src.b
 			if pulseOverride then srcColor.a = ( srcColor.a * brightness ) end
 			if istable(UC["dim"]) then
-				srcColor.r = Lerp( srcMod, UC.dim.r, UC.src.r )
-				srcColor.g = Lerp( srcMod, UC.dim.g, UC.src.g )
-				srcColor.b = Lerp( srcMod, UC.dim.b, UC.src.b )
+				local srcMod = ( viewDot * .5 ) * manualBloom
+				local dim = UC.dim
+				srcColor.r = Lerp( srcMod, dim.r, src.r )
+				srcColor.g = Lerp( srcMod, dim.g, src.g )
+				srcColor.b = Lerp( srcMod, dim.b, src.b )
 			end
 		end
 
-		if PHOTON_DEBUG and !PHOTON_DEBUG_EXCLUSIVE then srcColor = Color( 255, 255, 0, 255 ) elseif PHOTON_DEBUG and PHOTON_DEBUG_EXCLUSIVE then srcColor = Color( 0, 0, 0, 0 ) end
-		if PHOTON_DEBUG and PHOTON_DEBUG_LIGHT and lpos == PHOTON_DEBUG_LIGHT[1] then srcColor = Color( 0, 255, 255 ) end
-
-		local resultTable = { true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true }
+		if PHOTON_DEBUG and !PHOTON_DEBUG_EXCLUSIVE then writeColor( srcColor, 255, 255, 0, 255 ) elseif PHOTON_DEBUG and PHOTON_DEBUG_EXCLUSIVE then writeColor( srcColor, 0, 0, 0, 0 ) end
+		if PHOTON_DEBUG and PHOTON_DEBUG_LIGHT and lpos == PHOTON_DEBUG_LIGHT[1] then writeColor( srcColor, 0, 255, 255, 255 ) end
 
 		resultTable[1] = srcOnly
 		resultTable[2] = !srcSkip
@@ -328,19 +391,25 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 		resultTable[27] = parent
 
 		if istable( meta.EmitArray ) then
-			local emitResults = {}
+			-- Reuse the entry's emit vectors, tracking how many are live in this frame so
+			-- stale positions past the count are never drawn.
+			local emitPositions = resultTable.emitPositions
+			local emitCount = 0
 			for _key,_val in pairs( meta.EmitArray ) do
 				if not isvector( _val ) then continue end
-				emitResults[ #emitResults + 1 ] = Vector()
-				local insertRef = emitResults[ #emitResults ]
+				emitCount = emitCount + 1
+				local insertRef = emitPositions[ emitCount ]
+				if not insertRef then
+					insertRef = Vector()
+					emitPositions[ emitCount ] = insertRef
+				end
 				insertRef:Set( _val )
 				insertRef:Rotate( ua )
 				insertRef:Add( worldPos )
 			end
-			resultTable[24] = emitResults
+			emitPositions.n = emitCount
+			resultTable[24] = emitPositions
 		end
-
-		self:AddLightToQueue( resultTable )
 
 	end
 	end
@@ -379,7 +448,9 @@ function Photon.QuickDrawNoTable( srcOnly, drawSrc, camPos, camAng, srcSprite, s
 	if debug_mode == true then return end
 	if not srcOnly then
 		if istable( multiEmit ) then
-			for _,wPos in pairs( multiEmit ) do
+			-- multiEmit is a pooled array: only the first n entries belong to this frame.
+			for i = 1, ( multiEmit.n or #multiEmit ) do
+				local wPos = multiEmit[i]
 				setMaterial( mat1 )
 				drawSprite( wPos, (48 * bloomScale), (32 * bloomScale), colGlw )
 
@@ -537,7 +608,7 @@ end)
 function Photon:RenderQueue( effects )
 	local eyePos = EyePos()
 	local eyeAng = EyeAngles()
-	local count = #photonRenderTable
+	local count = photonRenderCount
 	if not effects then cam3d( eyePos, eyeAng ) else cam2d( eyePos, eyeAng ) end
 	if ( count > 0 ) then
 		local debug_mode = PHOTON_DEBUG
@@ -587,7 +658,7 @@ function Photon.DrawDirtyLensEffect()
 end
 
 function Photon.RenderDynamicLightQueue()
-	local count = #photonDynamicLights
+	local count = photonDynamicCount
 	if ( count > 0 ) then
 		for i=1, count do
 			if photonDynamicLights[i] != nil then

--- a/lua/autorun/photon/cl_photon_eng.lua
+++ b/lua/autorun/photon/cl_photon_eng.lua
@@ -86,7 +86,10 @@ local mat6 = Material("sprites/emv/effect_artifact2")
 local mat7 = Material("sprites/emv/dirty_lens_1")
 local mat8 = Material("sprites/emv/dirty_lens_2")
 
-local up1 = Vector()
+-- Scratch values reused across every light. PrepareVehicleLight fills each one and consumes
+-- it a few lines later without calling out in between, so a single instance is enough.
+local viewNormal = Vector()
+local lightAngle = Angle()
 
 -- Fixed corner rotations applied to dynamic light emission, indexed by emitDynamic.
 -- These are read-only: Rotate() mutates the vector being rotated, not the angle.
@@ -269,11 +272,10 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 	local lightNormal = ca:Forward()
 	lightNormal:Normalize()
 
-	local ViewNormal = Vector()
-	ViewNormal:Set(worldPos)
-	ViewNormal:Sub( useEyePos )
-	ViewNormal:Normalize()
-	viewDot = ViewNormal:Dot( lightNormal )
+	viewNormal:Set(worldPos)
+	viewNormal:Sub( useEyePos )
+	viewNormal:Normalize()
+	viewDot = viewNormal:Dot( lightNormal )
 
 	if ( viewDot and viewDot >= 0 ) then
 
@@ -313,13 +315,11 @@ function Photon:PrepareVehicleLight( parent, incolors, ilpos, gpos, lang, meta, 
 			srcOnly = true
 		end
 
-		local al = Angle()
-		al:Set(lang)
-		al.r = al.r - 90
-		if rotating then al.y = offset - 90 end
+		lightAngle:Set(lang)
+		lightAngle.r = lightAngle.r - 90
+		if rotating then lightAngle.y = offset - 90 end
 
-		up1:Set( worldPos )
-		local ua = parent:LocalToWorldAngles( al )
+		local ua = parent:LocalToWorldAngles( lightAngle )
 
 		local resultTable = acquireLightEntry()
 


### PR DESCRIPTION
Second of four stacked PRs for Â§5.2 of the codebase review. This is the core of the change and the highest-risk layer â€” the one worth reading closely.

Both light queues are emptied and rebuilt from scratch every frame, so everything they held became garbage a frame later: a 31-slot table per drawn light, a 4-slot table plus an `{r,g,b}` triple per dynamic light, a `Color` per light, a fresh `Vector` per emit position, and a 14-slot colour copy per light.

### Commits

- **Pool the render and dynamic light queues** â€” the queues keep their entries and track a live count instead of emptying themselves. `ClearLightQueue` rewinds the counts; the next frame overwrites entries in place. Entries past the count are the pool. Each entry owns its source colour and emit vectors, which are rewritten rather than rebuilt.
- **Read light colours directly instead of copying them per light** â€” every light built a 14-slot table and shallow-copied the whole colour table into it. All eight reads were by name, and every one of those names came from the table being copied, so the copy was equal to the original for every access.
- **Reuse scratch vector and angle across lights** â€” the view normal and sprite angle were allocated per light, filled with `:Set`, and consumed a few lines later without anything being called in between.

### Measured

From the InterBenchmark suite (report of 2026-08-14, LuaJIT 2.1.0-beta3, Ryzen 7 5800X). **Bold** is what this PR moves to, *italic* is what it replaces.

`Photon: Per-Light Result Tables`
| candidate | per call | vs fastest |
|---|---|---|
| **reused table (this PR)** | **66.15ns** | **100%** |
| *prefilled 31-slot literal (what this replaces)* | *107.50ns* | *163%* |
| fresh `{}` grown by index | 300.01ns | 454% |

38% off per drawn light, before counting the GC work that no longer happens. Note the third row: the pool still *creates* each entry as a prefilled literal, because growing an empty table one index at a time is far worse.

`Array Insertion` and `For Loops` — the queue plumbing itself

| what | before | after | |
|---|---|---|---|
| appending to a queue | `tab[#tab + 1]` — 72.46ns | counter index `tab[count]` — 4.22ns | ~17x |
| walking emit positions | `pairs` — 332.38ns | numeric `for` — 98.72ns | ~3.4x |

Both fall out of the pooling change rather than being aimed at: the queues and the emit array were appended to with `tab[#tab + 1]`, the slowest of six insertion forms measured, and the emit positions were walked with `pairs`, 3.4x the cost of a numeric loop. Tracking an explicit count replaces the first and enables the second.

`Photon: Colour Alpha Derivation`
| candidate | per call | vs fastest |
|---|---|---|
| mutate the palette colour in place | 47.54ns | 100% |
| **write fields into a reused colour (this PR)** | **50.22ns** | **106%** |
| `Color(r, g, b, a)` | 86.21ns | 181% |
| *`ColorAlpha(src, 255)` (what this replaces)* | *91.12ns* | *192%* |

45% off per light. The nominal winner is not available to us: it mutates `base` itself, which here is the vehicle's shared palette colour, so it would corrupt every other light using that colour.

`Photon: View Normal Vectors`
| candidate | per call | vs fastest |
|---|---|---|
| `(a - b)` then `:Normalize()` | 212.50ns | 100% |
| **reused scratch, `:Set`/`:Sub`/`:Normalize` (this PR)** | **239.00ns** | **112%** |
| `(a - b):GetNormalized()` | 246.87ns | 116% |
| *`Vector()` then `:Set`/`:Sub`/`:Normalize` (what this replaces)* | *282.38ns* | *133%* |

**This is the one place the benchmark does not simply endorse the change.** It is a 15% improvement on what was there, but the operator form is a further 11% faster still â€” because one C call beats two, and LuaJIT's allocation is cheap enough that it wins on throughput even though it allocates.

I kept the scratch anyway, and it is worth being explicit about why: the operator form reintroduces one `Vector` allocation per light per frame, which is the exact category of garbage Â§5.2 exists to remove. The CPU difference is ~27ns/call â€” around 0.3ms per second even at 12,000 light-draws/s â€” whereas the allocations are ~12,000 objects/s feeding the GC. A throughput microbenchmark under-weights that, because GC cost surfaces as frame-time spikes rather than mean call time, and the spikes are the actual complaint ("the classic Photon stutter"). Happy to switch it to `worldPos - useEyePos` if you would rather have the 11% â€” it is a one-line change.

### Review notes

The obvious objection is the one `photon_result_tables.lua` raises about its "reused table" variant: reuse is *"only safe when the consumer is done with the previous contents, which Photon's render queue is not."* That is true of a single shared table, which is not what this does. Each queue slot gets its own entry, so every light queued in a frame still has a distinct table; reuse only happens across frames, after the queue has been consumed and rewound.

The lifetime argument that makes this safe:

- Both queues are file-local, and `ClearLightQueue` is called exactly once per frame from `PreRender` (`DrawCarLights`), before either scan fills them.
- The render queue is consumed later in the same frame by `PreDrawEffects`, in two passes (3D then screen effects) that both read the same values.
- The dynamic queue is consumed in `Think`, which already read one frame behind and still does â€” the count is rewound at the same moment `table.Empty` used to run, so what is visible at any point is unchanged.

Other things worth checking:

- **Emit positions carry an explicit count.** A pooled array can hold more vectors than the current frame uses, so the leftovers must not be drawn. `QuickDrawNoTable` iterates that count, falling back to the array length so a plain table from an outside caller still draws.
- **Slots 15â€“20 are not pooled.** They reference the vehicle's persistent palette colours. This matters twice: `DrawScreenEffects` stashes `colAmb` in a module-local that `DrawDirtyLensEffect` reads later in the frame, and the colour trial above shows why mutating a palette colour in place is not an option.
- **`AddLightToQueue` is public**, so a third-party caller may park its own table at an index. The acquire helpers replace any entry that does not have the pooled layout rather than writing into it.
- The colour rewrite reproduces the old `ColorAlpha(src, 255)` exactly, including `a = 255 * brightness` under pulse override and the `dim` lerp overriding rgb.

### Testing

`glualint` is clean on every touched line. Not reachable from GLuaTest (client render path). The in-game pass this needs, specifically: a vehicle with `EmitArray` lights (stale emit positions), two vehicles with different colour sets lit at once (colour bleed between pooled entries), a rotating multicolour light, and `PHOTON_DEBUG` / `EMV_DEBUG` modes.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> â€¢ <a href="https://gh.io/stacks-feedback">Give Feedback ðŸ’¬</a></sub>
