### PR TITLE
perf: Sweep light submaterials in one hook instead of a timer each

### DIFF
--- a/lua/autorun/photon/cl_photon_eng.lua
+++ b/lua/autorun/photon/cl_photon_eng.lua
@@ -418,6 +418,54 @@ local endCam = cam.End3D2D
 local bloomRef = 0
 local bloomColor = nil
 
+-- Submaterials applied by a drawing light have to be cleared again once the light stops.
+-- This was a timer per submaterial per vehicle, created (or paused and restarted) on every
+-- frame the light drew, with its name rebuilt by concatenating the vehicle class, entity
+-- index and submaterial id each time. It is now a plain registry of the frame each
+-- submaterial was last drawn on, swept once per frame below.
+local submaterialHolds = {}
+
+local function holdSubMaterial( ent, submatId )
+	local held = submaterialHolds[ ent ]
+	if not held then
+		held = {}
+		submaterialHolds[ ent ] = held
+	end
+
+	held[ submatId ] = FrameNumber()
+end
+
+-- The vehicle model itself is drawn before PreDrawEffects, where lights are rendered, so a
+-- submaterial applied while drawing a light first shows up on the following frame. Holds are
+-- therefore kept for one frame after their last draw - clearing them any sooner would mean
+-- the submaterial never rendered at all.
+hook.Add( "Think", "Photon.ClearHeldSubMaterials", function()
+	local frame = FrameNumber()
+
+	for ent, held in pairs( submaterialHolds ) do
+		if not IsValid( ent ) then
+			submaterialHolds[ ent ] = nil
+			continue
+		end
+
+		local stillHeld = false
+		for submatId, lastFrame in pairs( held ) do
+			if ( frame - lastFrame ) > 1 then
+				ent:SetSubMaterial( submatId, nil )
+				held[ submatId ] = nil
+			else
+				stillHeld = true
+			end
+		end
+
+		if not stillHeld then submaterialHolds[ ent ] = nil end
+	end
+end )
+
+hook.Add( "EntityRemoved", "Photon.ClearHeldSubMaterials", function( ent )
+	submaterialHolds[ ent ] = nil
+end )
+
 function Photon.QuickDrawNoTable( srcOnly, drawSrc, camPos, camAng, srcSprite, srcT, srcR, srcB, srcL, worldPos, bloomScale, flareScale, widthScale, colSrc, colMed, colAmb, colBlm, colGlw, colRaw, colFlr, lightMod, cheap, viewFlare, multiEmit, SubmatID, SubmatMaterial, SubmatParent, debug_mode )
 
 	if drawSrc then
@@ -431,12 +479,7 @@ function Photon.QuickDrawNoTable( srcOnly, drawSrc, camPos, camAng, srcSprite, s
 
 	if SubmatID then
 		SubmatParent:SetSubMaterial(SubmatID, SubmatMaterial)
-		if !timer.Exists(SubmatParent:GetVehicleClass() .. SubmatParent:EntIndex() .. SubmatID) then
-			timer.Create( SubmatParent:GetVehicleClass() .. SubmatParent:EntIndex() .. SubmatID, FrameTime(), 1, function() if SubmatParent:IsValid() then SubmatParent:SetSubMaterial(SubmatID, nil) end end )
-		else
-			timer.Pause(SubmatParent:GetVehicleClass() .. SubmatParent:EntIndex() .. SubmatID)
-			timer.Start(SubmatParent:GetVehicleClass() .. SubmatParent:EntIndex() .. SubmatID)
-		end
+		holdSubMaterial( SubmatParent, SubmatID )
 	end
 
 	if debug_mode == true then return end


### PR DESCRIPTION
Third of four stacked PRs for §5.2 of the codebase review, covering the bullet about a timer created per submaterial light per frame.

Drawing a light with a submaterial created a timer for it, or paused and restarted the existing one, on **every frame that light drew**. The timer name was rebuilt each time by concatenating the vehicle class, entity index and submaterial id, so a vehicle with several submaterial lights churned strings and timer table entries continuously while its lights were on. It also called `GetVehicleClass` from the render path purely to build that name.

Lights now record the frame each submaterial was last drawn on, and a single `Think` hook clears the ones that have stopped. An `EntityRemoved` hook drops the registry entry, and the sweep discards invalid entities.

### Review notes

The timing is the part to check. Holds survive **one frame past their last draw**, not zero:

- The vehicle model is drawn during the opaque renderables pass, which happens *before* `PreDrawEffects`, where lights are rendered.
- So a submaterial applied while drawing a light first appears on the following frame's model draw.
- Clearing a hold as soon as the light stopped drawing would mean the submaterial never rendered at all.

This also removes a race rather than introducing one: the old code restarted a `FrameTime()` timer every frame from `PreDrawEffects` while the light drew, so whether it fired depended on where the timer poll landed relative to the restart. The frame counter is deterministic.

Removing the `GetVehicleClass` call from this path is a small robustness win too — it is the call guarded in #251 for non-vehicle parents.

### Testing

`glualint` is clean on every touched line. Not reachable from GLuaTest (client render path). Wants an in-game check on a vehicle with submaterial lights: the submaterial should be visible while the light runs and should clear promptly once it stops, with no flicker while it is running.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
