### PR TITLE
perf: Reuse per-vehicle frame tables and light index keys

### DIFF
--- a/lua/autorun/photon/cl_emv_meta.lua
+++ b/lua/autorun/photon/cl_emv_meta.lua
@@ -18,6 +18,20 @@ end)
 local IsValid = IsValid
 local tostring = tostring
 local istable = istable
+
+-- Light positions, pixel visibility and illumination blocks are all keyed by the light index
+-- as a string, while the render tables carry it as a number, so the render path converted it
+-- several times per light per frame. Indices are small and shared by every vehicle, so the
+-- conversions are memoised here instead.
+local lightKeyStrings = {}
+local function lightKey( index )
+	local key = lightKeyStrings[ index ]
+	if not key then
+		key = tostring( index )
+		lightKeyStrings[ index ] = key
+	end
+	return key
+end
 local math = math
 local isstring = isstring
 local system = system
@@ -377,8 +391,9 @@ function EMVU:MakeEMV( emv, name )
 			b = RenderTable[a]
 			if (b==true) then continue end
 			pos = positions[b[1]]
+			local lightIndexKey = lightKey( b[1] )
 			if istable(blockTable) then
-				if illumBlock then blockTable[tostring(b[1])] = true elseif blockTable[tostring(b[1])] then continue end
+				if illumBlock then blockTable[lightIndexKey] = true elseif blockTable[lightIndexKey] then continue end
 			end
 			if positions[b[1]] then
 				local colString = b[2]
@@ -432,10 +447,10 @@ function EMVU:MakeEMV( emv, name )
 						self, -- parent
 						col, -- color of the light (colors)
 						calcPos or pos[1], -- local pos if needed
-						gpos[b[1]] or gpos[tostring(b[1])], -- position (GLOBAL POS)
+						gpos[b[1]] or gpos[lightIndexKey], -- position (GLOBAL POS)
 						calcAng or pos[2], -- angle (lang)
 						meta[pos[3]], -- meta data (meta)
-						pixviscache[tostring(b[1])], -- pixvis handle (pixvis)
+						pixviscache[lightIndexKey], -- pixvis handle (pixvis)
 						a, -- int for dynamic light (lnum)
 						b[3], -- brightness
 						multiColor,
@@ -465,9 +480,14 @@ function EMVU:MakeEMV( emv, name )
 		local handles = self.EL.VisHandles
 		local usedLights = self:Photon_GetELUsedLights()
 		local usedPositions = self.PhotonELFramePositions
+		local pixVisCache = self.EL.PixVisCache
+		-- FetchUsedLights already stores these keys as strings, so they index the handle,
+		-- position and cache tables as they are; the three tostring calls per light per frame
+		-- were returning the key unchanged.
 		for index,_ in pairs( usedLights ) do
-			if not handles[tostring(index)] then self:Photon_SetupVisHandles() return end
-			self.EL.PixVisCache[ tostring(index) ] = util.PixelVisible( usedPositions[tostring(index)], 1, handles[tostring(index)] )
+			local handle = handles[index]
+			if not handle then self:Photon_SetupVisHandles() return end
+			pixVisCache[ index ] = util.PixelVisible( usedPositions[index], 1, handle )
 		end
 	end
 

--- a/lua/autorun/photon/cl_emv_meta.lua
+++ b/lua/autorun/photon/cl_emv_meta.lua
@@ -261,7 +261,18 @@ function EMVU:MakeEMV( emv, name )
 	function emv:Photon_UpdateFrameLightPositions()
 		local lights = self:Photon_GetELUsedLights()
 		local posData = EMVU.Positions[ self.VehicleName ]
-		local resultTable = {}
+
+		-- Reuse the vehicle's own table rather than building a new one every frame. It is
+		-- emptied first so a light that is no longer in use cannot leave a stale position
+		-- behind, which is what dropping the old table used to guarantee.
+		local resultTable = self.PhotonELFramePositions
+		if resultTable then
+			table.Empty( resultTable )
+		else
+			resultTable = {}
+			self.PhotonELFramePositions = resultTable
+		end
+
 		for key,_ in pairs( lights ) do
 			if PHOTON_DEBUG and not istable( posData[tonumber(key)] ) then continue end
 			local pData = posData[tonumber(key)]
@@ -273,8 +284,8 @@ function EMVU:MakeEMV( emv, name )
 				resultTable[key] = self:LocalToWorld( posData[tonumber(key)][1] )
 			end
 		end
-		self.PhotonELFramePositions = resultTable
-		return self.PhotonELFramePositions
+
+		return resultTable
 	end
 
 	-- Basic KV Shit --

--- a/lua/autorun/photon/cl_photon_meta.lua
+++ b/lua/autorun/photon/cl_photon_meta.lua
@@ -190,13 +190,22 @@ function Photon:SetupCar( ent, index )
 		self:ResetStateMaterials()
 		if not self.LastPhotonRenderCache or self.LastPhotonRenderCache + .05 < RealTime() then self.PhotonRenderCache = nil end
 
-		local RenderTable = { true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true }
+		local RenderTable = self.PhotonRenderCache
 
-		if istable( self.PhotonRenderCache ) then
+		if not istable( RenderTable ) then
+			-- The cache is rebuilt every .05s, but the table itself was being allocated on
+			-- every frame and then thrown away unused whenever the cache was still valid.
+			-- The vehicle keeps one table and refills it instead.
+			RenderTable = self.PhotonStateRenderTable
+			if RenderTable then
+				table.Empty( RenderTable )
+			else
+				RenderTable = {}
+				self.PhotonStateRenderTable = RenderTable
+			end
 
-			RenderTable = self.PhotonRenderCache
+			for i = 1, 72 do RenderTable[i] = true end
 
-		else
 			if headlights then
 				if Photon.Vehicles.States.Headlights[self.VehicleName] or pdebug then
 					for _,l in pairs(Photon.Vehicles.States.Headlights[self.VehicleName]) do

--- a/lua/autorun/photon/cl_photon_meta.lua
+++ b/lua/autorun/photon/cl_photon_meta.lua
@@ -266,8 +266,11 @@ function Photon:SetupCar( ent, index )
 
 		for i,light in pairs( RenderTable ) do
 			if light != true then
-				if string.StartWith(tostring(i), "_") then
-					self:SetStateMaterial( string.sub( tostring(i), 2 ), light[2] )
+				-- State material entries are keyed by an underscore-prefixed string; every
+				-- other key is a numeric light index, which can never start with one. Testing
+				-- the type first avoids converting each index to a string every frame.
+				if isstring(i) and string.StartWith(i, "_") then
+					self:SetStateMaterial( string.sub( i, 2 ), light[2] )
 				else
 					if not handles[light[1]] then setupVis( self ) return end -- for debugging mostly
 					local pos = positions[light[1]]


### PR DESCRIPTION
Last of four stacked PRs for §5.2 of the codebase review, covering the per-vehicle tables and the `tostring(index)` key churn.

### Commits

- **Reuse the per-vehicle frame light position table** — `Photon_UpdateFrameLightPositions` built a new table every frame for every vehicle with emergency lights on. The vehicle now keeps one table and empties it in place.
- **Stop rebuilding light index key strings every frame** — positions, pixel visibility and illumination blocks are keyed by the light index as a string, while the render tables carry it as a number, so rendering a light converted it up to three times per frame. Those conversions are memoised in a small shared table; the indices are small integers reused by every vehicle, so it stays tiny.
- **Stop allocating a discarded state render table each frame** — `Photon_RenderLights` allocated a 72-slot table at the top of every call and then immediately replaced it with the cached one. The cache is only rebuilt every .05s, so on most frames that table was built and thrown away without a slot being read.

### Review notes

- The frame position table is **emptied** rather than overwritten key by key. The set of used lights changes when the light option changes, and a light that has dropped out of the sequence must not keep a stale position — dropping the old table is what used to guarantee that.
- One behaviour difference worth naming: if a vehicle's position data is malformed, the loop still errors part way through, and the table now holds a partly filled set of positions instead of the previous frame's complete one. Either way that vehicle is already erroring every frame, and its missing lights are skipped by `PrepareVehicleLight`, which returns early without a world position.
- `Photon_RefreshELPixVis` was calling `tostring` on keys that are **already strings** — `FetchUsedLights` stores them with `tostring` — so it was handing back the same string three times per light. That is a readability fix more than a perf one; the real churn was on the numeric indices in `Photon_RenderLightTable`.
- The car light path had the same pattern in reverse: it converted every key to a string just to test for the `_` prefix marking a state material entry. Only string keys can carry that prefix, so checking the type first skips the conversion for the numeric indices that make up nearly all of them.
- The state render table is emptied before being reseeded because state material entries live under string keys, which a numeric-only reset would leave behind.

### Testing

`glualint` is clean on every touched line. Not reachable from GLuaTest (client render path). Wants an in-game check of emergency lights, illumination (the block table path), and car running/brake/blinker lights including a vehicle that uses state materials.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
