### PR TITLE
perf: Stop padding the car light render table with placeholders

### DIFF
--- a/lua/autorun/photon/cl_photon_meta.lua
+++ b/lua/autorun/photon/cl_photon_meta.lua
@@ -204,8 +204,6 @@ function Photon:SetupCar( ent, index )
 				self.PhotonStateRenderTable = RenderTable
 			end
 
-			for i = 1, 72 do RenderTable[i] = true end
-
 			if headlights then
 				if Photon.Vehicles.States.Headlights[self.VehicleName] or pdebug then
 					for _,l in pairs(Photon.Vehicles.States.Headlights[self.VehicleName]) do
@@ -273,6 +271,10 @@ function Photon:SetupCar( ent, index )
 
 		local light = false
 
+		-- Only lights that are actually on are in here, so this walks a handful of entries
+		-- rather than the 72 placeholder slots the table used to be padded out with. The
+		-- true check is kept for the hot-reload window, where a vehicle can still be holding
+		-- a cached table that was padded by the previous version of this file.
 		for i,light in pairs( RenderTable ) do
 			if light != true then
 				-- State material entries are keyed by an underscore-prefixed string; every


### PR DESCRIPTION
Follow-up to #265, prompted by the InterBenchmark report rather than by the codebase review. Stacked on top of it because it touches the same function.

`Photon_RenderLights` seeded its state render table with 72 `true` slots, and the draw loop skipped every one of them with `if light != true`. Nothing else read them — the table is only ever written by key, iterated once with `pairs`, and its length is never taken. A vehicle with four lights on walked 72 entries to find four.

### Why this is not an ipairs change

`pairs` has to stay. State material entries are keyed by underscore-prefixed strings, and the numeric light indices are sparse, so `ipairs` would stop at the first gap and skip state materials entirely. The saving is in the number of elements walked, not the iteration style.

From `For Loops` in the report of 2026-08-14 (LuaJIT 2.1.0-beta3, Ryzen 7 5800X), per element:

| | per element | vs fastest |
|---|---|---|
| `for i = 1, n` | 98.72ns | 100% |
| `ipairs` | 115.52ns | 117% |
| `pairs` | 332.38ns | 337% |

At 337% per element, dropping ~68 skipped elements per rebuild is worth more than any change of loop construct would be — and unlike a construct change, it is available without restructuring the table's key space.

### Review notes

- The `light != true` check is deliberately kept even though it is unreachable for a table built by this version. A `lua_refresh` leaves vehicles holding a cached table that the previous version padded, and that table survives until the .05s cache expires. Please don't let it get tidied away as dead code — the comment says as much.
- This removes the `for i = 1, 72 do RenderTable[i] = true end` line introduced one PR below. #265 kept the seeding deliberately, to keep its own change to pure table reuse with no behavioural component; the change in iteration set is isolated here so the two can be reviewed and reverted independently.
- Nothing depends on the table being dense: `git grep` confirms no `#RenderTable`, `table.Count` or `maxn` anywhere against it, and the loop passes the key straight through as `lnum`, so index values are unchanged.

### Testing

`glualint` clean on the touched lines. Not reachable from GLuaTest (client render path). Wants an in-game check of car running/brake/reverse/blinker lights, including a vehicle that uses state materials, since those are the string-keyed entries the loop distinguishes.

> **Note:** the commit on this branch is unsigned — my SSH agent (KeeAgent) was not exposing its named pipe at the time and signing was skipped deliberately. Happy to amend and force-push it signed before this merges.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
